### PR TITLE
renovate: do not bump major version for `k8s.io/*` deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,5 +15,14 @@
     "gomodTidy1.17",
     "gomodUpdateImportPaths"
   ],
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchPackagePrefixes": [
+        "k8s.io/"
+      ],
+      "allowedVersions": "<0.23"
+    }
+  ],
   "prHourlyLimit": 0
 }

--- a/.github/workflows/auto-render.yaml
+++ b/.github/workflows/auto-render.yaml
@@ -28,7 +28,6 @@ jobs:
         run: |2-
           export PATH=$PATH:$(go env GOPATH)/bin
           go-makefile-maker
-
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:

--- a/internal/renovate/renovate.go
+++ b/internal/renovate/renovate.go
@@ -73,10 +73,11 @@ func RenderConfig(assignees []string, goVersion string, enableGHActions bool) er
 	} else {
 		cfg.PostUpdateOptions = append([]string{"gomodTidy"}, cfg.PostUpdateOptions...)
 	}
+	// By default, Renovate is enabled for all managers including github-actions therefore
+	// we only set the GitHubActions field if we need to disable Renovate for
+	// github-actions manager.
 	if !enableGHActions {
-		// By default, Renovate is enabled for GitHub Actions so we need to disable it
-		// here manually in case it is not required.
-		cfg.GitHubActions = &githubActions{Enabled: enableGHActions}
+		cfg.GitHubActions = &githubActions{Enabled: false}
 	}
 
 	f, err := os.Create(".github/renovate.json")

--- a/main.go
+++ b/main.go
@@ -81,9 +81,9 @@ func main() {
 			}
 			cfg.Renovate.GoVersion = modFile.Go.Version
 		}
-		// Disable Renovate for GitHub actions except for go-makefile-maker itself.
-		disableForGHActions := !(len(cfg.Binaries) > 0 && cfg.Binaries[0].Name == "go-makefile-maker")
-		must(renovate.RenderConfig(cfg.GitHubWorkflow.Global.Assignees, cfg.Renovate.GoVersion, disableForGHActions))
+		// Only enable Renovate's github-actions manager for go-makefile-maker itself.
+		enableGHActions := len(cfg.Binaries) > 0 && cfg.Binaries[0].Name == "go-makefile-maker"
+		must(renovate.RenderConfig(cfg.GitHubWorkflow.Global.Assignees, cfg.Renovate.GoVersion, enableGHActions))
 	}
 }
 


### PR DESCRIPTION
We shouldn't update major versions for `k8s.io/*` dependencies.

From [`k8s.io/client-go` README](https://github.com/kubernetes/client-go): 

> We recommend using the `v0.x.y` tags for Kubernetes releases >=` v1.17.0 `.

I am using `k8s.io/` prefix instead of `k8s.io/client-go` explicitly because it is probably best that all `k8s.io` deps have same major versions, i.e. `v0.x.y`.

Example of why this is a problem: https://github.com/sapcc/gatekeeper-addons/pull/10