### PR TITLE
ghworkflow: add envtest binary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ ci:
   postgres:
     enabled: true
     version: 12
+  kubernetesEnvtest:
+    enabled: true
+    version: 1.22.x!
   ignorePaths: []
 ```
 
@@ -305,6 +308,13 @@ If `postgres.enabled` is `true` then a PostgreSQL service container will be adde
 `postgres.version` specifies the Docker Hub image tag for the [`postgres`
 image][docker-hub-postgres] that is used for this container. By default `12` is used as
 image tag.
+
+If `kubernetesEnvtest.enabled` is `true` then
+[Envtest](https://book.kubebuilder.io/reference/envtest.html) binaries will be downloaded
+using
+[`setup-envtest`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/tools/setup-envtest)
+for the `test` job. The version for binaries can be specified using the
+`kubernetesEnvtest.version` field. By default `1.22.x!` is used as the version.
 
 `ignorePaths` is the same as `global.ignorePaths` and can be used to override it for this particular workflow.
 

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -124,6 +124,10 @@ type CIWorkflowConfig struct {
 		Enabled bool   `yaml:"enabled"`
 		Version string `yaml:"version"`
 	} `yaml:"postgres"`
+	KubernetesEnvtest struct {
+		Enabled bool   `yaml:"enabled"`
+		Version string `yaml:"version"`
+	} `yaml:"kubernetesEnvtest"`
 }
 
 // LicenseWorkflowConfig appears in type Configuration.
@@ -200,13 +204,13 @@ func (c *Configuration) Validate() error {
 		}
 
 		// Validate CI workflow configuration.
-		if ghwCfg.CI.Postgres.Enabled {
+		if ghwCfg.CI.Postgres.Enabled || ghwCfg.CI.KubernetesEnvtest.Enabled {
 			if !ghwCfg.CI.Enabled {
-				return errors.New("githubWorkflow.ci.enabled needs to be set to 'true' when githubWorkflow.ci.postgres.enabled is 'true'")
+				return errors.New("githubWorkflow.ci.enabled needs to be set to 'true' when githubWorkflow.ci.postgres or githubWorkflow.ci.kubernetesEnvtest is enabled")
 			}
 			if len(ghwCfg.CI.RunnerOSList) > 0 {
 				if len(ghwCfg.CI.RunnerOSList) > 1 || !strings.HasPrefix(ghwCfg.CI.RunnerOSList[0], "ubuntu") {
-					return errors.New("githubWorkflow.ci.runOn must only define a single Ubuntu based runner when githubWorkflow.ci.postgres.enabled is 'true'")
+					return errors.New("githubWorkflow.ci.runOn must only define a single Ubuntu based runner when githubWorkflow.ci.postgres or githubWorkflow.ci.kubernetesEnvtest is enabled")
 				}
 			}
 		}

--- a/internal/ghworkflow/defaults.go
+++ b/internal/ghworkflow/defaults.go
@@ -20,8 +20,9 @@ import "strings"
 // Constants
 
 const (
-	defaultPostgresVersion = "12"
-	defaultRunnerOS        = "ubuntu-latest"
+	defaultPostgresVersion   = "12"
+	defaultK8sEnvtestVersion = "1.22.x!"
+	defaultRunnerOS          = "ubuntu-latest"
 )
 
 const (

--- a/internal/ghworkflow/workflow.go
+++ b/internal/ghworkflow/workflow.go
@@ -141,13 +141,16 @@ func (j *job) addStep(s jobStep) {
 
 // jobStep is a task that is run as part of a job.
 type jobStep struct {
+	// A name for your step to display on GitHub.
+	Name string `yaml:"name"`
+
 	// A unique identifier for the step. You can use the id to reference the
 	// step in contexts.
 	// Ref: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
 	ID string `yaml:"id,omitempty"`
 
-	// A name for your step to display on GitHub.
-	Name string `yaml:"name"`
+	// You can use the if conditional to prevent a step from running unless a condition is met.
+	If string `yaml:"if,omitempty"`
 
 	// Selects an action to run as part of a step in your job.
 	//


### PR DESCRIPTION
If you're working with k8s, e.g. in controllers, then one usually requires envtest binaries for writing tests.

Although, we only use envtest in absent-metrics-operator but this functionality is minimal to implement and others can also potentially benefit from it therefore the PR.