### PR TITLE
render image references in Dockerfiles directly, without vars

### DIFF
--- a/internal/renovate/renovate.go
+++ b/internal/renovate/renovate.go
@@ -49,7 +49,7 @@ func (c *config) addPackageRule(rule PackageRule) {
 	c.PackageRules = append(c.PackageRules, rule)
 }
 
-func RenderConfig(assignees []string, customPackageRules []PackageRule, goVersion string, enableGHActions bool) error {
+func RenderConfig(assignees []string, customPackageRules []PackageRule, goVersion string, isGoMakefileMakerRepo bool) error {
 	cfg := config{
 		Extends: []string{
 			"config:base",
@@ -93,10 +93,14 @@ func RenderConfig(assignees []string, customPackageRules []PackageRule, goVersio
 	} else {
 		cfg.PostUpdateOptions = append([]string{"gomodTidy"}, cfg.PostUpdateOptions...)
 	}
-	if !enableGHActions {
+	if !isGoMakefileMakerRepo {
 		cfg.addPackageRule(PackageRule{
 			MatchDepTypes:  []string{"action"},
-			EnableRenovate: &enableGHActions,
+			EnableRenovate: &isGoMakefileMakerRepo,
+		})
+		cfg.addPackageRule(PackageRule{
+			MatchDepTypes:  []string{"dockerfile"},
+			EnableRenovate: &isGoMakefileMakerRepo,
 		})
 	}
 

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func main() {
 			cfg.Renovate.GoVersion = modFileGoVersion
 		}
 		// Only enable Renovate for github-actions for go-makefile-maker itself.
-		enableGHActions := goModulePath == "github.com/sapcc/go-makefile-maker"
-		util.Must(renovate.RenderConfig(cfg.GitHubWorkflow.Global.Assignees, cfg.Renovate.PackageRules, cfg.Renovate.GoVersion, enableGHActions))
+		isGoMakefileMakerRepo := goModulePath == "github.com/sapcc/go-makefile-maker"
+		util.Must(renovate.RenderConfig(cfg.GitHubWorkflow.Global.Assignees, cfg.Renovate.PackageRules, cfg.Renovate.GoVersion, isGoMakefileMakerRepo))
 	}
 }


### PR DESCRIPTION
The templating is breaking the mirror injection in our CI since the injection does not dare to touch `FROM` lines containing variable interpolations. Since we will now receive the Renovate PRs on this repo instead of in the individual repos, we can get rid of the variable interpolations in the generated Makefiles.

@SuperSandro2000 I don't have the time right now to look into the Renovate config. Can you please check that Renovate won't generate PRs for these image references in the downstream repos?