### PR TITLE
Fixes example for docker entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Since only entire packages (not single source files) can be selected for coverag
 ```yaml
 dockerfile:
   enabled: true
-  entrypoint: { "/bin/bash", "--", "--arg" }
+  entrypoint: [ "/bin/bash", "--", "--arg" ]
   extraIgnores:
     - tmp
     - files


### PR DESCRIPTION
Dockerfile Entrypoint is expected as a list rather than a map.
[docker.go#L65](https://github.com/sapcc/go-makefile-maker/blob/a59683750a75daeb385bccf21d84c7cc0d5be92e/internal/dockerfile/docker.go#L65)

Using the example from the docs I was facing this:
> FATAL: yaml: unmarshal errors:
  line 20: cannot unmarshal !!map into []string
