### PR TITLE
Revert "disable renovatebot automerges during the Christmas break"

### DIFF
--- a/internal/renovate/renovate.go
+++ b/internal/renovate/renovate.go
@@ -97,7 +97,7 @@ func RenderConfig(
 	cfg.addPackageRule(PackageRule{
 		MatchPackagePatterns: []string{`^github\.com\/sapcc\/.*`},
 		GroupName:            "github.com/sapcc",
-		AutoMerge:            false, //NOTE: disabled for the Christmas break, TODO: reenable afterwards
+		AutoMerge:            true,
 	})
 
 	// combine all dependencies not under github.com/sapcc/


### PR DESCRIPTION
This reverts commit 8f91f3432cf4825dc858ebc185751550f21a69f5. Please merge this in the new year.