### PR TITLE
renovate config: set custom value for CommitMessageAction

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,7 @@
   "assignees": [
     "SuperSandro2000"
   ],
+  "commitMessageAction": "Renovate: Update",
   "constraints": {
     "go": "1.20"
   },

--- a/internal/renovate/renovate.go
+++ b/internal/renovate/renovate.go
@@ -29,14 +29,15 @@ type constraints struct {
 }
 
 type config struct {
-	Extends           []string      `json:"extends"`
-	Assignees         []string      `json:"assignees,omitempty"`
-	Constraints       constraints   `json:"constraints"`
-	PostUpdateOptions []string      `json:"postUpdateOptions"`
-	PackageRules      []PackageRule `json:"packageRules,omitempty"`
-	PrHourlyLimit     int           `json:"prHourlyLimit"`
-	Schedule          []string      `json:"schedule"`
-	SemanticCommits   string        `json:"semanticCommits,omitempty"`
+	Extends             []string      `json:"extends"`
+	Assignees           []string      `json:"assignees,omitempty"`
+	CommitMessageAction string        `json:"commitMessageAction"`
+	Constraints         constraints   `json:"constraints"`
+	PostUpdateOptions   []string      `json:"postUpdateOptions"`
+	PackageRules        []PackageRule `json:"packageRules,omitempty"`
+	PrHourlyLimit       int           `json:"prHourlyLimit"`
+	Schedule            []string      `json:"schedule"`
+	SemanticCommits     string        `json:"semanticCommits,omitempty"`
 }
 
 type PackageRule struct {
@@ -82,6 +83,11 @@ func RenderConfig(
 			"github>whitesource/merge-confidence:beta",
 		},
 		Assignees: assignees,
+		// CommitMessageAction is the verb that appears at the start of Renovate's
+		// commit messages (and therefore, PR titles). The default value is "Update".
+		// We choose something more specific because some of us have filter rules
+		// in their mail client to separate Renovate PRs from other PRs.
+		CommitMessageAction: "Renovate: Update",
 		Constraints: constraints{
 			Go: goVersion,
 		},


### PR DESCRIPTION
I want to have a filter rule in my mail client that matches only notifications for Renovate PRs, but not other GitHub notifications. Because Renovatebot is not the only user participating in this PR, I cannot filter on From. Realistically only the PR title can be used as a basis for the rule.

Setting the PR title directly is supported in Renovate, but support is deprecated. By default, the PR title is equal to the commit message.

Out of all fields in the commit message that can be customized, the obvious choices are commitMessageAction (the verb at the start, "Update" by default) or commitMessageExtra (a suffix at the end, empty by default). To avoid making commit messages and PR titles even longer, I'm going with the first option and setting commitMessageAction to "Renovate" instead of "Update". This is reasonably specific for my mail filter while still fitting into the existing sentence well.