### PR TITLE
upgrade Go to 1.21.0

### DIFF
--- a/internal/dockerfile/Dockerfile.template
+++ b/internal/dockerfile/Dockerfile.template
@@ -1,4 +1,4 @@
 # renovate: datasource=docker depName=alpine versioning=docker
 ARG ALPINE_VERSION=3.18
 # renovate: datasource=docker depName=golang versioning=docker
-ARG GOLANG_VERSION=1.20.7-alpine
+ARG GOLANG_VERSION=1.21.0-alpine

--- a/internal/dockerfile/docker.go
+++ b/internal/dockerfile/docker.go
@@ -94,7 +94,7 @@ RUN apk add --no-cache --no-progress gcc git make musl-dev
 
 COPY . /src
 ARG BININFO_BUILD_DATE BININFO_COMMIT_HASH BININFO_VERSION # provided to 'make install'
-RUN make -C /src install PREFIX=/pkg%[4]s
+RUN make -C /src install PREFIX=/pkg GOTOOLCHAIN=local%[4]s
 
 ################################################################################
 


### PR DESCRIPTION
This adds GOTOOLCHAIN=local to the Docker image build to avoid surprising toolchain downloads.

FYI: After merging, please unpause the Castellum job in the go-makefile-maker pipeline.