### PR TITLE
core/scan: only set UsesPostgres on direct dep

### DIFF
--- a/internal/core/scan.go
+++ b/internal/core/scan.go
@@ -56,7 +56,7 @@ func Scan() ScanResult {
 				hasBinInfo = true
 			}
 		}
-		if v.Mod.Path == "github.com/lib/pq" {
+		if v.Mod.Path == "github.com/lib/pq" && !v.Indirect {
 			usesPostgres = true
 		}
 	}


### PR DESCRIPTION
A project that is not actually using postgres still gets the `with-postgres-db.sh` created, if `github.com/lib/pq` is an indirect dependency.
With this change only projects that directly reference the module will get the testing script rendered.