### PR TITLE
add additional linter & dotimportwhitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ golangciLint:
     - (*net/http.Client).Do
   skipDirs:
     - easypg/migrate/*
+  additionalLinters:
+    - ginkgolinter
+  dotImportWhitelist:
+    - github.com/onsi/ginkgo/v2
 ```
 
 The `make check` and `make static-check` targets use [`golangci-lint`](https://golangci-lint.run) to lint your code.
@@ -236,6 +240,10 @@ Additionally, if `createConfig` is `true`, you can specify a list of files skipp
 and a list of functions to be excluded from `errcheck` linter in `errcheckExcludes` field.
 Refer to [`errcheck`'s README](https://github.com/kisielk/errcheck#excluding-functions) for info on the format
 for function signatures that `errcheck` accepts.
+
+With `additionalLinters` you can add a list of extra linters to be enabled in the generated config file. The list of available linters can be found [here](https://golangci-lint.run/usage/linters/).
+
+With `dotImportWhitelist` it is possible to exclude libraries that are usually dot imported such as Ginkgo and Gomega from the `stylecheck` linter. The list expects the full import path of the library.
 
 Take a look at `go-makefile-maker`'s own [`golangci-lint` config file](./.golangci.yaml) for an up-to-date example of what the generated config would look like.
 

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -95,9 +95,11 @@ type GolangConfiguration struct {
 
 // GolangciLintConfiguration appears in type Configuration.
 type GolangciLintConfiguration struct {
-	CreateConfig     bool     `yaml:"createConfig"`
-	ErrcheckExcludes []string `yaml:"errcheckExcludes"`
-	SkipDirs         []string `yaml:"skipDirs"`
+	CreateConfig       bool     `yaml:"createConfig"`
+	ErrcheckExcludes   []string `yaml:"errcheckExcludes"`
+	SkipDirs           []string `yaml:"skipDirs"`
+	AdditionalLinters  []string `yaml:"additionalLinters"`
+	DotImportWhitelist []string `yaml:"dotImportWhitelist"`
 }
 
 type GoreleaserConfiguration struct {

--- a/internal/golangcilint/golangci_lint.go
+++ b/internal/golangcilint/golangci_lint.go
@@ -101,6 +101,15 @@ linters-settings:
 			- unnecessaryDefer
 			- weakCond
 			- yodaStyleExpr
+{{- if .DotImportWhitelist }}
+  stylecheck:
+  {{- if .DotImportWhitelist }}
+    dot-import-whitelist:
+    {{- range .DotImportWhitelist }}
+      - {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 	goimports:
 		# Put local imports after 3rd-party packages.
 		local-prefixes: {{ .ModulePath }}
@@ -175,6 +184,11 @@ linters:
 		- unused
 		- usestdlibvars
 		- whitespace
+{{- if .AdditionalLinters }}
+  {{- range .AdditionalLinters }}
+    - {{ . }}
+  {{- end }}
+{{- end }}
 `, "\t", "  "))))
 
 type configTmplData struct {
@@ -183,6 +197,8 @@ type configTmplData struct {
 	MisspellIgnoreWords []string
 	ErrcheckExcludes    []string
 	SkipDirs            []string
+	DotImportWhitelist  []string
+	AdditionalLinters   []string
 }
 
 func RenderConfig(cfg core.GolangciLintConfiguration, vendoring bool, modulePath string, misspellIgnoreWords []string) {
@@ -199,6 +215,8 @@ func RenderConfig(cfg core.GolangciLintConfiguration, vendoring bool, modulePath
 		MisspellIgnoreWords: misspellIgnoreWords,
 		ErrcheckExcludes:    cfg.ErrcheckExcludes,
 		SkipDirs:            cfg.SkipDirs,
+		DotImportWhitelist:  cfg.DotImportWhitelist,
+		AdditionalLinters:   cfg.AdditionalLinters,
 	}))
 	fmt.Fprintln(f) // empty line at end
 


### PR DESCRIPTION
A number of projects I am working on use Ginkgo and Gomega for writing tests.
Usually Ginkgo and Gomega are dot imported, which is flagged by the `stylecheck` linter.
So I have to manually exclude the paths for these two libs in the `.golangci.yaml`:
```yaml
stylecheck:
  dot-import-whitelist:
    - github.com/onsi/ginkgo/v2
    - github.com/onsi/gomega
  ```
Also I am enabling the `ginkgolinter`, which provides some valuable suggestions for the usage of ginkgo.

I would like to be able to specify this in the `Makefile.maker.yaml`, as currently I have to remember to re-add these configurations after running `go-makefile-maker`.

Since not every Go project is using these two libraries for testing, I was hesitant to add the configuration as a default to the `.golangci.yaml` template. 
Another option I considered was adding a ginkgo/gomega specific option to the config to add these configurations if that option is set. But this would be very specific and the individual flags allow others use-cases as well.