### PR TITLE
GoReleaser: remove Homebrew Tap from config

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -46,7 +46,7 @@ type Configuration struct {
 	Coverage       CoverageConfiguration        `yaml:"coverageTest"`
 	Golang         GolangConfiguration          `yaml:"golang"`
 	GolangciLint   GolangciLintConfiguration    `yaml:"golangciLint"`
-	Goreleaser     GoreleaserConfiguration      `yaml:"goreleaser"`
+	GoReleaser     GoReleaserConfiguration      `yaml:"goReleaser"`
 	SpellCheck     SpellCheckConfiguration      `yaml:"spellCheck"`
 	GitHubWorkflow *GithubWorkflowConfiguration `yaml:"githubWorkflow"`
 	Makefile       MakefileConfig               `yaml:"makefile"`
@@ -100,8 +100,8 @@ type GolangciLintConfiguration struct {
 	SkipDirs         []string `yaml:"skipDirs"`
 }
 
-type GoreleaserConfiguration struct {
-	Enabled bool `yaml:"enabled"`
+type GoReleaserConfiguration struct {
+	CreateConfig bool `yaml:"createConfig"`
 }
 
 // SpellCheckConfiguration appears in type Configuration.

--- a/internal/ghworkflow/workflow_release.go
+++ b/internal/ghworkflow/workflow_release.go
@@ -37,7 +37,10 @@ func releaseWorkflow(cfg *core.GithubWorkflowConfiguration) {
 	}
 	j.addStep(jobStep{
 		Name: "Generate release info",
-		Run:  "make build/release-info",
+		Run: makeMultilineYAMLString([]string{
+			"go install github.com/sapcc/go-bits/tools/release-info@latest",
+			"release-info CHANGELOG.md $(shell git describe --tags --abbrev=0) > build/release-info",
+		}),
 	})
 	j.addStep(jobStep{
 		Name: "Run GoReleaser",

--- a/internal/ghworkflow/workflow_release.go
+++ b/internal/ghworkflow/workflow_release.go
@@ -23,7 +23,7 @@ func releaseWorkflow(cfg *core.GithubWorkflowConfiguration) {
 		return
 	}
 
-	w.Permissions.Contents = tokenScopeWrite
+	w.Permissions.Contents = tokenScopeRead
 	w.Permissions.Packages = tokenScopeWrite
 
 	w.On.Push.Branches = nil

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 	}
 
 	// Render Goreleaser config file
-	if cfg.Goreleaser.Enabled {
+	if cfg.GoReleaser.CreateConfig {
 		goreleaser.RenderConfig(cfg)
 	}
 


### PR DESCRIPTION
and:
- use `createConfig` for option key as it conveys the intent better similiar to `golangciLint.createConfig`.
- use `.yaml` for file extension in order to be consistent with GitHub workflow and golangci-lint config files.