### PR TITLE
Allow specifying Docker build platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,9 +408,12 @@ sheet][ref-pattern-cheat-sheet]. This option is not defined by default.
 
 If `enabled` is set to true, the generated `Dockerfile` is build and pushed to repository path under `ghcr.io`.
 
+To build for more or other platforms than the default (linux/amd64), you can set the `platforms` field to a list of platforms to build for. The format is the same as for the `--platform` flag of `docker buildx build`.
+
 ```yaml
 pushContainerToGhcr:
   enabled: true
+  platforms: linux/amd64,linux/arm64
 ```
 
 ### `githubWorkflow.release`

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -152,7 +152,8 @@ type LicenseWorkflowConfig struct {
 }
 
 type PushContainerToGhcrConfig struct {
-	Enabled bool `yaml:"enabled"`
+	Enabled   bool   `yaml:"enabled"`
+	Platforms string `yaml:"platforms"`
 }
 
 type ReleaseWorkflowConfig struct {

--- a/internal/core/constants.go
+++ b/internal/core/constants.go
@@ -35,6 +35,8 @@ const (
 
 	DockerLoginAction     = "docker/login-action@v3"
 	DockerMetadataAction  = "docker/metadata-action@v5"
+	DockerBuildxAction    = "docker/setup-buildx-action@v3"
+	DockerQemuAction      = "docker/setup-qemu-action@v3"
 	DockerBuildPushAction = "docker/build-push-action@v5"
 
 	CodeqlInitAction      = "github/codeql-action/init@v2"


### PR DESCRIPTION
I think a default of `linux/amd64,linux/arm64` would be fantastic, but didn't know if that would too opinionated for this tool.