### PR TITLE
fix(lint): replace Deadline, remove rpc-default-path

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,7 +4,7 @@
 ################################################################################
 
 run:
-  deadline: 3m # 1m by default
+  timeout: 3m # 1m by default
   modules-download-mode: vendor
 
 output:
@@ -91,7 +91,6 @@ linters-settings:
     http-method: true
     http-status-code: true
     os-dev-null: true
-    rpc-default-path: true
     time-weekday: true
     time-month: true
     time-layout: true

--- a/internal/golangcilint/golangci_lint.go
+++ b/internal/golangcilint/golangci_lint.go
@@ -27,7 +27,7 @@ import (
 
 var configTmpl = template.Must(template.New("golangci").Parse(strings.TrimSpace(strings.ReplaceAll(`
 run:
-	deadline: 3m # 1m by default
+	timeout: 3m # 1m by default
 	modules-download-mode: {{ .ModDownloadMode }}
 	{{- if .SkipDirs }}
 	skip-dirs:
@@ -133,7 +133,6 @@ linters-settings:
 		http-method: true
 		http-status-code: true
 		os-dev-null: true
-		rpc-default-path: true
 		time-weekday: true
 		time-month: true
 		time-layout: true


### PR DESCRIPTION
The current config is having lint errors for the fields `run.default` and `issues.usestdlibvars.rpc-default-path`.

`default` should be replaced by timeout as per https://github.com/golangci/golangci-lint/blob/a4e223761c4dcc4b03bce6b27d8b9887507cb9cf/pkg/config/run.go#L28-L31

`rpc-default-path` looks like a typo of `default-rpc-path` (https://github.com/golangci/golangci-lint/blob/a4e223761c4dcc4b03bce6b27d8b9887507cb9cf/pkg/config/linters_settings.go#L862) Which is already covered by the config.