### PR TITLE
Fix ginkgo for kubernetes controller development

### DIFF
--- a/internal/core/scan.go
+++ b/internal/core/scan.go
@@ -74,6 +74,8 @@ func Scan() ScanResult {
 		}
 		if v.Mod.Path == "k8s.io/api" {
 			kubernetesVersion = strings.ReplaceAll(v.Mod.Version, "v0", "1")
+			splitted := strings.Split(kubernetesVersion, ".")
+			kubernetesVersion = strings.Join(splitted[:len(splitted)-1], ".")
 		}
 		if v.Mod.Path == "sigs.k8s.io/controller-runtime" {
 			kubernetesController = true


### PR DESCRIPTION
- setup-envtest does not provide builds for all k8s versions, so stop considering patch versions
- ginkgos -coverprofile behaves differently than gotests
- remove ginkgos -p flag