### PR TITLE
Go Install gingko also the latest

### DIFF
--- a/internal/makefile/makefile.go
+++ b/internal/makefile/makefile.go
@@ -133,7 +133,7 @@ endif
 			recipe: []string{
 				`@if ! hash ginkgo 2>/dev/null; then` +
 					` printf "\e[1;36m>> Installing ginkgo...\e[0m\n";` +
-					` go install github.com/onsi/ginkgo/v2/ginkgo; fi`,
+					` go install github.com/onsi/ginkgo/v2/ginkgo@latest; fi`,
 			},
 			target: "install-ginkgo",
 		})


### PR DESCRIPTION
All other tools are installed that way, and ginkgo is the odd duck standing out.
Also, it fails at least for me locally with go 1.22