### PR TITLE
fix(golangci-lint): remove unknown option

### DIFF
--- a/internal/golangcilint/golangci_lint.go
+++ b/internal/golangcilint/golangci_lint.go
@@ -139,7 +139,6 @@ linters-settings:
 		default-rpc-path: true
 		http-method: true
 		http-status-code: true
-		rpc-default-path: true
 		sql-isolation-level: true
 		time-layout: true
 		time-month: true


### PR DESCRIPTION
The correct option is called `default-rpc-path` which already exists in the config.