### PR TITLE
Match case of FROM with AS to silence warning

### DIFF
--- a/internal/dockerfile/docker.go
+++ b/internal/dockerfile/docker.go
@@ -102,7 +102,7 @@ RUN %s --version 2>/dev/null`, binary.Name)
 	runCommands := strings.Join(commands, " \\\n  && ")
 
 	dockerfile := fmt.Sprintf(
-		`FROM golang:%[1]s-alpine%[2]s as builder
+		`FROM golang:%[1]s-alpine%[2]s AS builder
 
 RUN apk add --no-cache --no-progress ca-certificates gcc git make musl-dev
 


### PR DESCRIPTION
Docker (at least 27.0.3) prints a warning:
> WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match
> (line 1)

This should fix it.