### PR TITLE
adds GO_BUILDENV variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ This user account is intended for use with all payloads that do not require a ro
 
 ```yaml
 variables:
+  GO_BUILDENV: ''
   GO_BUILDFLAGS: '-mod vendor'
   GO_LDFLAGS: ''
   GO_TESTENV: ''
@@ -192,6 +193,13 @@ auto-generate suitable linker flags to fill the global variables in the `bininfo
 ```yaml
 variables:
   GO_TESTENV: 'POSTGRES_HOST=localhost POSTGRES_DATABASE=unittestdb'
+```
+
+`GO_BUILDENV` can contain environment variables to pass to `go build`:
+
+```yaml
+variables:
+  GO_BUILDENV: 'CGO_CFLAGS=-D_LARGEFILE64_SOURCE'
 ```
 
 ### `golang`

--- a/internal/makefile/makefile.go
+++ b/internal/makefile/makefile.go
@@ -166,6 +166,7 @@ endif
 	build.addDefinition("GO_BUILDFLAGS =%s", cfg.Variable("GO_BUILDFLAGS", defaultBuildFlags))
 	build.addDefinition("GO_LDFLAGS =%s", cfg.Variable("GO_LDFLAGS", strings.TrimSpace(defaultLdFlags)))
 	build.addDefinition("GO_TESTENV =%s", cfg.Variable("GO_TESTENV", ""))
+	build.addDefinition("GO_BUILDENV =%s", cfg.Variable("GO_BUILDENV", ""))
 	if sr.KubernetesController {
 		build.addDefinition("TESTBIN=$(shell pwd)/testbin")
 	}
@@ -456,7 +457,7 @@ func buildTargets(binaries []core.BinaryConfiguration, sr golang.ScanResult) []r
 			phony:       true,
 			target:      "build/" + bin.Name,
 			recipe: []string{fmt.Sprintf(
-				"go build $(GO_BUILDFLAGS) -ldflags '%s $(GO_LDFLAGS)' -o build/%s %s",
+				"@env $(GO_BUILDENV) go build $(GO_BUILDFLAGS) -ldflags '%s $(GO_LDFLAGS)' -o build/%s %s",
 				makeDefaultLinkerFlags(bin.Name, sr),
 				bin.Name, bin.FromPackage,
 			)},


### PR DESCRIPTION
implements a possibility to set env variables via `GO_BUILDENV` to `go build`:

```
variables:
  GO_BUILDENV: 'CGO_CFLAGS=-D_LARGEFILE64_SOURCE'
```