### PR TITLE
remove obsolete Renovate configuration options

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,18 +27,16 @@
       "allowedVersions": "1.22.x"
     },
     {
-      "matchPackagePatterns": [
-        "^github\\.com\\/sapcc\\/.*"
+      "matchPackageNames": [
+        "/^github\\.com\\/sapcc\\/.*/"
       ],
       "automerge": true,
       "groupName": "github.com/sapcc"
     },
     {
-      "excludePackagePatterns": [
-        "^github\\.com\\/sapcc\\/.*"
-      ],
-      "matchPackagePatterns": [
-        ".*"
+      "matchPackageNames": [
+        "!/^github\\.com\\/sapcc\\/.*/",
+        "/.*/"
       ],
       "groupName": "External dependencies"
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base",
+    "config:recommended",
     "default:pinDigestsDisabled",
     "mergeConfidence:all-badges",
     "docker:enableMajor",

--- a/README.md
+++ b/README.md
@@ -290,7 +290,6 @@ renovate:
   goVersion: 1.18
   packageRules:
     - matchPackageNames: []
-      matchPackagePrefixes: []
       matchUpdateTypes: []
       matchDepTypes: []
       matchFiles: []
@@ -309,23 +308,25 @@ Additionally, you can also define [`packageRules`](https://docs.renovatebot.com/
 
 ```yaml
 packageRules:
-  - matchPackagePatterns: [".*"]
-    groupName: "all" # group all PRs together
-  - matchPackageNames: ["golang"]
-    allowedVersions: $goVersion.x
-  - matchDepTypes: ["action"]
-    enabled: false # because github-actions will be updated by go-makefile-maker itself, see githubWorkflow config section below.
-  - matchDepTypes: ["dockerfile"]
-    enabled: false # because dockerfile will be updated by go-makefile-maker itself, see docker config section above.
+  # Group PRs for library dependencies together.
+  - matchPackageNames: [ "!/^github\\.com\\/sapcc\\/.*/", "/.*/" ]
+    groupName: "External dependencies"
+    automerge: false
+  - matchPackageNames: [ "/^github\\.com\\/sapcc\\/.*/" ]
+    groupName: "github.com/sapcc"
+    automerge: true
+
   # This package rule will be added if go.mod file has a `k8s.io/*` dependency.
-  - matchPackagePrefixes: ["k8s.io/"]
-    allowedVersions: 0.25.x
-  # This package rule will be added along with the required matchPackagePrefixes if go.mod file has the respective dependencies.
-  - matchPackagePrefixes:
-      - github.com/sapcc/go-api-declarations
-      - github.com/sapcc/gophercloud-sapcc
-      - github.com/sapcc/go-bits
-    autoMerge: true
+  - matchPackagePrefixes: ["/^k8s.io\\//"]
+    allowedVersions: 0.28.x
+
+  # Restrict updates for versions managed by go-makefile-maker.
+  - matchPackageNames: [ golang ]
+    allowedVersions: $goVersion.x # only update within the same minor release
+  - matchDepTypes: [ action ]
+    enabled: false # see githubWorkflow config section below
+  - matchDepTypes: [ dockerfile ]
+    enabled: false # see docker config section above
 ```
 
 ### `verbatim`

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -162,17 +162,14 @@ type SecurityChecksWorkflowConfig struct {
 }
 
 type PackageRule struct {
-	ExcludePackagePatterns []string `yaml:"excludePackagePatterns" json:"excludePackagePatterns,omitempty"`
-	MatchPackageNames      []string `yaml:"matchPackageNames" json:"matchPackageNames,omitempty"`
-	MatchPackagePatterns   []string `yaml:"matchPackagePatterns" json:"matchPackagePatterns,omitempty"`
-	MatchPackagePrefixes   []string `yaml:"matchPackagePrefixes" json:"matchPackagePrefixes,omitempty"`
-	MatchUpdateTypes       []string `yaml:"matchUpdateTypes" json:"matchUpdateTypes,omitempty"`
-	MatchDepTypes          []string `yaml:"matchDepTypes" json:"matchDepTypes,omitempty"`
-	MatchFiles             []string `yaml:"matchFiles" json:"matchFiles,omitempty"`
-	AllowedVersions        string   `yaml:"allowedVersions" json:"allowedVersions,omitempty"`
-	AutoMerge              bool     `yaml:"automerge" json:"automerge,omitempty"`
-	EnableRenovate         *bool    `yaml:"enabled" json:"enabled,omitempty"`
-	GroupName              string   `yaml:"groupName" json:"groupName,omitempty"`
+	MatchPackageNames []string `yaml:"matchPackageNames" json:"matchPackageNames,omitempty"`
+	MatchUpdateTypes  []string `yaml:"matchUpdateTypes" json:"matchUpdateTypes,omitempty"`
+	MatchDepTypes     []string `yaml:"matchDepTypes" json:"matchDepTypes,omitempty"`
+	MatchFiles        []string `yaml:"matchFiles" json:"matchFiles,omitempty"`
+	AllowedVersions   string   `yaml:"allowedVersions" json:"allowedVersions,omitempty"`
+	AutoMerge         bool     `yaml:"automerge" json:"automerge,omitempty"`
+	EnableRenovate    *bool    `yaml:"enabled" json:"enabled,omitempty"`
+	GroupName         string   `yaml:"groupName" json:"groupName,omitempty"`
 }
 
 // RenovateConfig appears in type Configuration.

--- a/internal/renovate/renovate.go
+++ b/internal/renovate/renovate.go
@@ -72,7 +72,7 @@ func RenderConfig(cfgRenovate core.RenovateConfig, scanResult golang.ScanResult,
 
 	cfg := config{
 		Extends: []string{
-			"config:base",
+			"config:recommended",
 			"default:pinDigestsDisabled",
 			"mergeConfidence:all-badges",
 		},

--- a/internal/renovate/renovate.go
+++ b/internal/renovate/renovate.go
@@ -107,17 +107,16 @@ func RenderConfig(cfgRenovate core.RenovateConfig, scanResult golang.ScanResult,
 
 	// combine and automerge all dependencies under github.com/sapcc/
 	cfg.addPackageRule(core.PackageRule{
-		MatchPackagePatterns: []string{`^github\.com\/sapcc\/.*`},
-		GroupName:            "github.com/sapcc",
-		AutoMerge:            true,
+		MatchPackageNames: []string{`/^github\.com\/sapcc\/.*/`},
+		GroupName:         "github.com/sapcc",
+		AutoMerge:         true,
 	})
 
 	// combine all dependencies not under github.com/sapcc/
 	cfg.addPackageRule(core.PackageRule{
-		MatchPackagePatterns:   []string{`.*`},
-		ExcludePackagePatterns: []string{`^github\.com\/sapcc\/.*`},
-		GroupName:              "External dependencies",
-		AutoMerge:              false,
+		MatchPackageNames: []string{`!/^github\.com\/sapcc\/.*/`, `/.*/`},
+		GroupName:         "External dependencies",
+		AutoMerge:         false,
 	})
 
 	// Only enable Dockerfile and github-actions updates for go-makefile-maker itself.
@@ -134,7 +133,7 @@ func RenderConfig(cfgRenovate core.RenovateConfig, scanResult golang.ScanResult,
 	}
 	if hasK8sIOPkgs {
 		cfg.addPackageRule(core.PackageRule{
-			MatchPackagePrefixes: []string{"k8s.io/"},
+			MatchPackageNames: []string{`/^k8s.io\//`},
 			// Since our clusters use k8s v1.26 and k8s has a support policy of -/+ 1 minor version we set the allowedVersions to `0.27.x`.
 			// k8s.io/* deps use v0.x.y instead of v1.x.y therefore we use 0.x instead of 1.x.
 			// Ref: https://docs.renovatebot.com/configuration-options/#allowedversions

--- a/internal/renovate/renovate.go
+++ b/internal/renovate/renovate.go
@@ -138,6 +138,7 @@ func RenderConfig(cfgRenovate core.RenovateConfig, scanResult golang.ScanResult,
 			// k8s.io/* deps use v0.x.y instead of v1.x.y therefore we use 0.x instead of 1.x.
 			// Ref: https://docs.renovatebot.com/configuration-options/#allowedversions
 			AllowedVersions: "0.28.x",
+			// ^ NOTE: When bumping this version, also adjust the rendition of this rule in the README appropriately.
 		})
 	}
 


### PR DESCRIPTION
Based on the config migration PR that was opened on one of the internal repos.

I would also like to suggest that we have g-m-m set <https://docs.renovatebot.com/configuration-options/#configmigration> if the repo is under github.com/sapcc, to allow us to get notifications about these sorts of things more reliably.