### PR TITLE
makefile: fix spacing of addlicense options

### DIFF
--- a/internal/makefile/makefile.go
+++ b/internal/makefile/makefile.go
@@ -375,13 +375,14 @@ endif
 			allSourceFilesExpr = `$(shell find -name *.rs)`
 		}
 
-		ignoreOptions := []string{}
+		var ignoreOptions []string
 		if cfg.GitHubWorkflow != nil {
 			for _, pattern := range cfg.GitHubWorkflow.License.IgnorePatterns {
 				// quoting avoids glob expansion
 				ignoreOptions = append(ignoreOptions, fmt.Sprintf("-ignore %q", pattern))
 			}
 		}
+		ignoreOptionsStr := strings.Join(append(ignoreOptions, "--"), " ")
 
 		dev.addRule(rule{
 			description:   "Add license headers to all non-vendored source code files.",
@@ -390,10 +391,7 @@ endif
 			prerequisites: []string{"prepare-static-check"},
 			recipe: []string{
 				`@printf "\e[1;36m>> addlicense\e[0m\n"`,
-				fmt.Sprintf(`@addlicense -c "SAP SE" %s-- %s`,
-					strings.Join(ignoreOptions, " "),
-					allSourceFilesExpr,
-				)},
+				fmt.Sprintf(`@addlicense -c "SAP SE" %s %s`, ignoreOptionsStr, allSourceFilesExpr)},
 		})
 
 		dev.addRule(rule{
@@ -403,10 +401,7 @@ endif
 			prerequisites: []string{"prepare-static-check"},
 			recipe: []string{
 				`@printf "\e[1;36m>> addlicense --check\e[0m\n"`,
-				fmt.Sprintf(`@addlicense --check %s-- %s`,
-					strings.Join(ignoreOptions, " "),
-					allSourceFilesExpr,
-				)},
+				fmt.Sprintf(`@addlicense --check %s %s`, ignoreOptionsStr, allSourceFilesExpr)},
 		})
 
 		if isGolang {


### PR DESCRIPTION
If there are options, the previous implementation put the `--` directly after the last option without a space, so the `--` would be interpreted as part of the ignore pattern. For example:

https://github.com/sapcc/gophercloud-sapcc/blob/8caa1617c0c9bf9d2ae2f2f6c48253492b3e13af/Makefile#L72