### PR TITLE
golangci-lint: disable type assertion checks in errcheck linter

### DIFF
--- a/internal/golangcilint/golangci_lint.go
+++ b/internal/golangcilint/golangci_lint.go
@@ -63,8 +63,10 @@ linters-settings:
 	errcheck:
 		# Report about assignment of errors to blank identifier.
 		check-blank: true
-		# Report about not checking of errors in type assertions.
-		check-type-assertions: true
+		# Do not report about not checking of errors in type assertions.
+		# This is not as dangerous as skipping error values because an unchecked type assertion just immediately panics.
+		# We disable this because it makes a ton of useless noise esp. in test code.
+		check-type-assertions: false
 		{{- if .ErrcheckExcludes }}
 		exclude-functions:
 			{{- range .ErrcheckExcludes }}


### PR DESCRIPTION
I probably should have done this before spending most of yesterday putting in a billion nolints.