### PR TITLE
renovate: replace matchFiles with matchFileNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ renovate:
     - matchPackageNames: []
       matchUpdateTypes: []
       matchDepTypes: []
-      matchFiles: []
+      matchFileNames: []
       allowedVersions: ""
       autoMerge: false
       enabled: false

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -169,7 +169,7 @@ type PackageRule struct {
 	MatchPackageNames []string `yaml:"matchPackageNames" json:"matchPackageNames,omitempty"`
 	MatchUpdateTypes  []string `yaml:"matchUpdateTypes" json:"matchUpdateTypes,omitempty"`
 	MatchDepTypes     []string `yaml:"matchDepTypes" json:"matchDepTypes,omitempty"`
-	MatchFiles        []string `yaml:"matchFiles" json:"matchFiles,omitempty"`
+	MatchFileNames    []string `yaml:"matchFileNames" json:"matchFileNames,omitempty"`
 	AllowedVersions   string   `yaml:"allowedVersions" json:"allowedVersions,omitempty"`
 	AutoMerge         bool     `yaml:"automerge" json:"automerge,omitempty"`
 	EnableRenovate    *bool    `yaml:"enabled" json:"enabled,omitempty"`


### PR DESCRIPTION
`matchFiles` is deprecated by Renovate. The documentation only explains `matchFileNames`: https://docs.renovatebot.com/configuration-options/#matchfilenames

As far as I can see, this option is only used by Keppel (and by a few repos that incorrectly cargo-culted from Keppel): https://github.com/search?q=matchFiles%20org%3Asapcc&type=code