### PR TITLE
disable renovatebot automerges during the Christmas break

### DIFF
--- a/internal/renovate/renovate.go
+++ b/internal/renovate/renovate.go
@@ -99,7 +99,7 @@ func RenderConfig(cfgRenovate core.RenovateConfig, scanResult golang.ScanResult,
 		cfg.addPackageRule(core.PackageRule{
 			MatchPackageNames: []string{`/^github\.com\/sapcc\/.*/`},
 			GroupName:         "github.com/sapcc",
-			AutoMerge:         true,
+			AutoMerge:         false, //NOTE: disabled for the Christmas break, TODO: reenable afterwards
 		})
 
 		// combine all dependencies not under github.com/sapcc/


### PR DESCRIPTION
In case a hotfix needs to be deployed, that should not require deploying unrelated version upgrades while the full crew is not on deck.