### PR TITLE
Revert "disable renovatebot automerges during the Christmas break"

### DIFF
--- a/internal/renovate/renovate.go
+++ b/internal/renovate/renovate.go
@@ -99,7 +99,7 @@ func RenderConfig(cfgRenovate core.RenovateConfig, scanResult golang.ScanResult,
 		cfg.addPackageRule(core.PackageRule{
 			MatchPackageNames: []string{`/^github\.com\/sapcc\/.*/`},
 			GroupName:         "github.com/sapcc",
-			AutoMerge:         false, //NOTE: disabled for the Christmas break, TODO: reenable afterwards
+			AutoMerge:         true,
 		})
 
 		// combine all dependencies not under github.com/sapcc/


### PR DESCRIPTION
Please only approve. I have a calendar reminder to merge this after New Year.