### PR TITLE
add config option: dockerfile.extraBuildStages

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,12 @@ Since only entire packages (not single source files) can be selected for coverag
 dockerfile:
   enabled: true
   entrypoint: [ "/bin/bash", "--", "--arg" ]
+  extraBuildStages:
+    - |
+      FROM ghcr.io/foobar/big-toolbox AS toolbox
   extraDirectives:
-    - 'LABEL mylabel=myvalu'
+    - 'LABEL mylabel=myvalue'
+    - 'COPY --from=toolbox /bin/fancytool /usr/bin/fancytool'
   extraIgnores:
     - tmp
     - files
@@ -148,6 +152,7 @@ As an additional smoke test, the compiled binaries are invoked with the `--versi
 With [go-api-declarations](https://github.com/sapcc/go-api-declarations)'s [`bininfo.HandleVersionArgument` function](https://pkg.go.dev/github.com/sapcc/go-api-declarations/bininfo#HandleVersionArgument), this can be implemented in one line. If you are using Cobra or any other library to handle arguments, the [`bininfo.Version` function](https://pkg.go.dev/github.com/sapcc/go-api-declarations/bininfo#Version) is recommended instead.
 
 * `entrypoint` allows overwriting the final entrypoint.
+* `extraBuildStages` prepends additional build stages at the top of the Dockerfile. This is useful for bringing in precompiled assets from other images, or if a non-Go compilation step is required.
 * `extraDirectives` appends additional directives near the end of the Dockerfile.
 * `extraIgnores` appends entries in `.dockerignore` to the default ones.
 * `extraPackages` installs extra Alpine packages in the final Docker layer. `ca-certificates` is always installed.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ dockerfile:
   extraBuildStages:
     - |
       FROM ghcr.io/foobar/big-toolbox AS toolbox
+      RUN toolbox-cmd
   extraDirectives:
     - 'LABEL mylabel=myvalue'
     - 'COPY --from=toolbox /bin/fancytool /usr/bin/fancytool'

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -176,6 +176,7 @@ type RenovateConfig struct {
 type DockerfileConfig struct {
 	Enabled          bool     `yaml:"enabled"`
 	Entrypoint       []string `yaml:"entrypoint"`
+	ExtraBuildStages []string `yaml:"extraBuildStages"`
 	ExtraDirectives  []string `yaml:"extraDirectives"`
 	ExtraIgnores     []string `yaml:"extraIgnores"`
 	ExtraPackages    []string `yaml:"extraPackages"`


### PR DESCRIPTION
For my ocm-helm-toolbox image, I need to bring in the `ocm` and `helm` binaries. Building OCM in particular is hairy and best done in its own separate build stage, so this adds the option to define extra build stages. Artifacts built there can then be brought into the final image by putting COPY directives in `extraDirectives`.