### PR TITLE
stylecheck: add github.com/majewsky/gg/option to dot-import-whitelist

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -107,6 +107,7 @@ linters-settings:
     require-specific: true
   stylecheck:
     dot-import-whitelist:
+      - github.com/majewsky/gg/option
       - github.com/onsi/ginkgo/v2
       - github.com/onsi/gomega
   usestdlibvars:

--- a/internal/golangcilint/golangci_lint.go
+++ b/internal/golangcilint/golangci_lint.go
@@ -137,6 +137,7 @@ linters-settings:
 	{{- end }}
 	stylecheck:
 		dot-import-whitelist:
+			- github.com/majewsky/gg/option
 			- github.com/onsi/ginkgo/v2
 			- github.com/onsi/gomega
 	usestdlibvars:


### PR DESCRIPTION
With Go 1.24.0, I want to replace pointer types by Option types across my repos (where appropriate). The Option type's package is supposed to be used as a dot import, so I would like to allow it as such.