### PR TITLE
feat(renovate): add customManagers and extend packageRules

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,9 +270,12 @@ renovate:
       matchUpdateTypes: []
       matchDepTypes: []
       matchFileNames: []
+      extends: []
       allowedVersions: ""
+      minimumReleaseAge: ""
       autoMerge: false
       enabled: false
+  customManagers: []
 ```
 
 Generate [RenovateBot](https://renovatebot.com/) config to automatically create pull requests weekly on Fridays with dependency updates.
@@ -304,6 +307,23 @@ packageRules:
     enabled: false # see githubWorkflow config section below
   - matchDepTypes: [ dockerfile ]
     enabled: false # see docker config section above
+```
+
+You can also define [`customManagers`](https://docs.renovatebot.com/modules/manager/regex/). An example to detect `ENVTEST_K8S_VERSION` env variable version and update it in `Makefile`
+
+```yaml
+customManagers:
+  - customType: "regex"
+    description: "Bump envtest version in the Makefile"
+    fileMatch: [
+      "^Makefile$"
+    ]
+    matchStrings: [
+      "ENVTEST_K8S_VERSION\\s*\\?=\\s*(?<currentValue>.?(?:\\d+\\.){0,2}\\d+)"
+    ]
+    datasourceTemplate: "github-tags"
+    depNameTemplate: "kubernetes-sigs/controller-tools"
+    extractVersionTemplate: "^envtest.v(?<version>.*)$"
 ```
 
 ### `spellCheck`

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -158,18 +158,21 @@ type PackageRule struct {
 	MatchUpdateTypes  []string `yaml:"matchUpdateTypes" json:"matchUpdateTypes,omitempty"`
 	MatchDepTypes     []string `yaml:"matchDepTypes" json:"matchDepTypes,omitempty"`
 	MatchFileNames    []string `yaml:"matchFileNames" json:"matchFileNames,omitempty"`
+	Extends           []string `yaml:"extends" json:"extends,omitempty"`
 	AllowedVersions   string   `yaml:"allowedVersions" json:"allowedVersions,omitempty"`
 	AutoMerge         bool     `yaml:"automerge" json:"automerge,omitempty"`
 	EnableRenovate    *bool    `yaml:"enabled" json:"enabled,omitempty"`
 	GroupName         string   `yaml:"groupName" json:"groupName,omitempty"`
+	MinimumReleaseAge string   `yaml:"minimumReleaseAge" json:"minimumReleaseAge,omitempty"`
 }
 
 // RenovateConfig appears in type Configuration.
 type RenovateConfig struct {
-	Enabled      bool          `yaml:"enabled"`
-	Assignees    []string      `yaml:"assignees"`
-	GoVersion    string        `yaml:"goVersion"`
-	PackageRules []PackageRule `yaml:"packageRules"`
+	Enabled        bool          `yaml:"enabled"`
+	Assignees      []string      `yaml:"assignees"`
+	GoVersion      string        `yaml:"goVersion"`
+	PackageRules   []PackageRule `yaml:"packageRules"`
+	CustomManagers []interface{} `yaml:"customManagers"`
 }
 
 // DockerfileConfig appears in type Configuration.


### PR DESCRIPTION
adding 2 new fields to  `packageRules`:

- `extends` -> I'm using it in a this context: 
 If you want to automatically pin action digests add the `helpers:pinGitHubActionDigests` preset to the extends array:
- `minimumReleaseAge` - > Time required before a new release is considered stable. 

Introducing CustomManagers to be able to automate version updates in `Makefile` using regex. an example can be found in docs update
