### PR TITLE
Support disabling REUSE.toml override

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The config file has the following sections:
 * [golangciLint](#golangcilint)
 * [goReleaser](#goreleaser)
 * [makefile](#makefile)
+* [reuse](#reuse)
 * [metadata](#metadata)
 * [renovate](#renovate)
 * [spellCheck](#spellcheck)
@@ -233,6 +234,18 @@ makefile:
 `makefile` contains settings related to the higher level `Makefile` generation.
 
 `enabled` is an optional setting to disable the `Makefile` generation completely.
+If not specified, the setting is treated as being set to true to maintain backwards compatibility with older configs.
+
+### `reuse`
+
+```yaml
+reuse:
+  enabled: false
+```
+
+`reuse` contains settings related to the [REUSE](https://reuse.software/) config generation.
+
+`enabled` is an optional setting to disable the REUSE config generation completely.
 If not specified, the setting is treated as being set to true to maintain backwards compatibility with older configs.
 
 ### `metadata`

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -39,6 +39,7 @@ type Configuration struct {
 	Renovate       RenovateConfig               `yaml:"renovate"`
 	SpellCheck     SpellCheckConfiguration      `yaml:"spellCheck"`
 	Test           TestConfiguration            `yaml:"testPackages"`
+	Reuse          ReuseConfiguration           `yaml:"reuse"`
 	Verbatim       string                       `yaml:"verbatim"`
 	VariableValues map[string]string            `yaml:"variables"`
 }
@@ -67,6 +68,11 @@ type BinaryConfiguration struct {
 type TestConfiguration struct {
 	Only   string `yaml:"only"`
 	Except string `yaml:"except"`
+}
+
+// ReuseConfiguration appears in type Configuration.
+type ReuseConfiguration struct {
+	Enabled *bool `yaml:"enabled"`
 }
 
 // CoverageConfiguration appears in type Configuration.

--- a/internal/makefile/makefile.go
+++ b/internal/makefile/makefile.go
@@ -427,8 +427,13 @@ endif
 		})
 
 		if isGolang {
-			reuseConfigFile := "REUSE.toml"
-			must.Succeed(os.WriteFile(reuseConfigFile, reuseConfig, 0o666))
+			// If disabled, the REUSE.toml file should not be overridden.
+			// This is useful if the project needs additional information in
+			// the REUSE.toml file, e.g., specific disclaimers.
+			if cfg.Reuse.Enabled == nil || *cfg.Reuse.Enabled {
+				reuseConfigFile := "REUSE.toml"
+				must.Succeed(os.WriteFile(reuseConfigFile, reuseConfig, 0o666))
+			}
 
 			licenseRulesFile := ".license-scan-rules.json"
 			must.Succeed(os.WriteFile(licenseRulesFile, licenseRules, 0o666))


### PR DESCRIPTION
Currently, any changes to REUSE.toml will be overridden by go-makefile-maker. However, there are some projects which need a modified version of the REUSE.toml provided here. For example, Apeiro projects under github.com/cobaltcore-dev should include a legal disclaimer in `SPDX-PackageComment`. This pull request adds a config flag `reuse.enabled` that can be used to disable overrides of the REUSE.toml file. 