### PR TITLE
Fix `controllerGen` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ controllerGen:
   enabled: true
   crdOutputPath: config/crd/bases
   objectHeaderFile: boilerplate.go.txt
-  rbacRoleName: manager-role crd webhook
+  rbacRoleName: manager-role
 ```
 
 Customization options for controller-gen.


### PR DESCRIPTION
Fix example of `controllerGen.rbacRoleName` entry, as it produces invalid command that doesn't run - [ref](https://github.com/sapcc/go-makefile-maker/blob/edf64173579fe0da6898f96347847f1e1d9101d6/internal/makefile/makefile.go#L272).

```
controller-gen crd rbac:roleName=manager-role crd webhook webhook paths=./... output:crd:artifacts:config=config/crd/bases
```

```
...
Error: multiple instances of 'crd' generator specified
Usage:
  controller-gen [flags]
...
run `controller-gen crd rbac:roleName=manager-role crd webhook webhook paths=./... output:crd:artifacts:config=config/crd/bases -w` to see all available markers, or `controller-gen crd rbac:roleName=manager-role crd webhook webhook paths=./... output:crd:artifacts:config=config/crd/bases -h` for usage
make: *** [generate] Error 1
```

