### PR TITLE
Update golangci-lint to version 2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: SAP SE
+# SPDX-License-Identifier: Apache-2.0
+
+root = true
+
+[*]
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[{Makefile,go.mod,go.sum,*.go}]
+indent_style = tab
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{LICENSE,LICENSES/*,vendor/**}]
+charset = unset
+end_of_line = unset
+indent_size = unset
+indent_style = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -31,7 +31,7 @@ jobs:
           check-latest: true
           go-version: 1.24.1
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: latest
       - name: Dependency Licenses Review

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,127 +6,35 @@
 # Copyright 2024 SAP SE
 # SPDX-License-Identifier: Apache-2.0
 
+version: "2"
 run:
-  timeout: 3m0s # 1m by default
   modules-download-mode: vendor
+  timeout: 3m0s # none by default in v2
 
-output:
-  # Do not print lines of code with issue.
-  print-issued-lines: false
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      # Put local imports after 3rd-party packages
+      local-prefixes:
+        - github.com/sapcc/go-makefile-maker
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
 issues:
-  exclude:
-    # It is idiomatic Go to reuse the name 'err' with ':=' for subsequent errors.
-    # Ref: https://go.dev/doc/effective_go#redeclaration
-    - 'declaration of "err" shadows declaration at'
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - bodyclose
-  # '0' disables the following options.
+  # '0' disables the following options
   max-issues-per-linter: 0
   max-same-issues: 0
 
-linters-settings:
-  errcheck:
-    # Report about assignment of errors to blank identifier.
-    check-blank: true
-    # Do not report about not checking of errors in type assertions.
-    # This is not as dangerous as skipping error values because an unchecked type assertion just immediately panics.
-    # We disable this because it makes a ton of useless noise esp. in test code.
-    check-type-assertions: false
-  forbidigo:
-    analyze-types: true # required for pkg:
-    forbid:
-      # ioutil package has been deprecated: https://github.com/golang/go/issues/42026
-      - ^ioutil\..*$
-      # Using http.DefaultServeMux is discouraged because it's a global variable that some packages silently and magically add handlers to (esp. net/http/pprof).
-      # Applications wishing to use http.ServeMux should obtain local instances through http.NewServeMux() instead of using the global default instance.
-      - ^http\.DefaultServeMux$
-      - ^http\.Handle(?:Func)?$
-      # Forbid usage of old and archived square/go-jose
-      - pkg: ^gopkg\.in/square/go-jose\.v2$
-        msg: "gopk.in/square/go-jose is archived and has CVEs. Replace it with gopkg.in/go-jose/go-jose.v2"
-      - pkg: ^github.com/coreos/go-oidc$
-        msg: "github.com/coreos/go-oidc depends on gopkg.in/square/go-jose which has CVEs. Replace it with github.com/coreos/go-oidc/v3"
-
-      - pkg: ^github.com/howeyc/gopass$
-        msg: "github.com/howeyc/gopass is archived, use golang.org/x/term instead"
-  goconst:
-    ignore-tests: true
-    min-occurrences: 5
-  gocritic:
-    enabled-checks:
-      - boolExprSimplify
-      - builtinShadow
-      - emptyStringTest
-      - evalOrder
-      - httpNoBody
-      - importShadow
-      - initClause
-      - methodExprCall
-      - paramTypeCombine
-      - preferFilepathJoin
-      - ptrToRefParam
-      - redundantSprint
-      - returnAfterHttpError
-      - stringConcatSimplify
-      - timeExprSimplify
-      - truncateCmp
-      - typeAssertChain
-      - typeUnparen
-      - unnamedResult
-      - unnecessaryBlock
-      - unnecessaryDefer
-      - weakCond
-      - yodaStyleExpr
-  goimports:
-    # Put local imports after 3rd-party packages.
-    local-prefixes: github.com/sapcc/go-makefile-maker
-  gomoddirectives:
-    go-version-pattern: '1\.\d+(\.0)?$'
-    replace-allow-list:
-      # for go-pmtud
-      - github.com/mdlayher/arp
-    toolchain-forbidden: true
-  gosec:
-    excludes:
-      # gosec wants us to set a short ReadHeaderTimeout to avoid Slowloris attacks, but doing so would expose us to Keep-Alive race conditions (see https://iximiuz.com/en/posts/reverse-proxy-http-keep-alive-and-502s/)
-      - G112
-      # created file permissions are restricted by umask if necessary
-      - G306
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-  nolintlint:
-    require-specific: true
-  stylecheck:
-    dot-import-whitelist:
-      - github.com/majewsky/gg/option
-      - github.com/onsi/ginkgo/v2
-      - github.com/onsi/gomega
-  usestdlibvars:
-    constant-kind: true
-    crypto-hash: true
-    default-rpc-path: true
-    http-method: true
-    http-status-code: true
-    sql-isolation-level: true
-    time-layout: true
-    time-month: true
-    time-weekday: true
-    tls-signature-scheme: true
-  usetesting:
-    os-temp-dir: true
-  whitespace:
-    # Enforce newlines (or comments) after multi-line function signatures.
-    multi-func: true
-
 linters:
-  # We use 'disable-all' and enable linters explicitly so that a newer version
-  # does not introduce new linters unexpectedly.
-  disable-all: true
+  # Disable all pre-enabled linters and enable them explicitly so that a newer version does not introduce new linters unexpectedly
+  default: none
   enable:
     - bodyclose
     - containedctx
@@ -142,11 +50,8 @@ linters:
     - gocheckcompilerdirectives
     - goconst
     - gocritic
-    - gofmt
-    - goimports
     - gomoddirectives
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - intrange
@@ -160,11 +65,126 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused
     - usestdlibvars
     - usetesting
     - whitespace
+  settings:
+    errcheck:
+      check-type-assertions: false
+      # Report about assignment of errors to blank identifier.
+      check-blank: true
+      # Do not report about not checking of errors in type assertions.
+      # This is not as dangerous as skipping error values because an unchecked type assertion just immediately panics.
+      # We disable this because it makes a ton of useless noise esp. in test code.
+    forbidigo:
+      analyze-types: true # required for pkg:
+      forbid:
+        # ioutil package has been deprecated: https://github.com/golang/go/issues/42026
+        - pattern: ^ioutil\..*$
+        # Using http.DefaultServeMux is discouraged because it's a global variable that some packages silently and magically add handlers to (esp. net/http/pprof).
+        # Applications wishing to use http.ServeMux should obtain local instances through http.NewServeMux() instead of using the global default instance.
+        - pattern: ^http\.DefaultServeMux$
+        - pattern: ^http\.Handle(?:Func)?$
+        - pkg: ^gopkg\.in/square/go-jose\.v2$
+          msg: gopk.in/square/go-jose is archived and has CVEs. Replace it with gopkg.in/go-jose/go-jose.v2
+        - pkg: ^github.com/coreos/go-oidc$
+          msg: github.com/coreos/go-oidc depends on gopkg.in/square/go-jose which has CVEs. Replace it with github.com/coreos/go-oidc/v3
+        - pkg: ^github.com/howeyc/gopass$
+          msg: github.com/howeyc/gopass is archived, use golang.org/x/term instead
+    goconst:
+      min-occurrences: 5
+    gocritic:
+      enabled-checks:
+        - boolExprSimplify
+        - builtinShadow
+        - emptyStringTest
+        - evalOrder
+        - httpNoBody
+        - importShadow
+        - initClause
+        - methodExprCall
+        - paramTypeCombine
+        - preferFilepathJoin
+        - ptrToRefParam
+        - redundantSprint
+        - returnAfterHttpError
+        - stringConcatSimplify
+        - timeExprSimplify
+        - truncateCmp
+        - typeAssertChain
+        - typeUnparen
+        - unnamedResult
+        - unnecessaryBlock
+        - unnecessaryDefer
+        - weakCond
+        - yodaStyleExpr
+    gomoddirectives:
+      replace-allow-list:
+        # for go-pmtud
+        - github.com/mdlayher/arp
+      toolchain-forbidden: true
+      go-version-pattern: 1\.\d+(\.0)?$
+    gosec:
+      excludes:
+        # gosec wants us to set a short ReadHeaderTimeout to avoid Slowloris attacks, but doing so would expose us to Keep-Alive race conditions (see https://iximiuz.com/en/posts/reverse-proxy-http-keep-alive-and-502s/
+        - G112
+        # created file permissions are restricted by umask if necessary
+        - G306
+    govet:
+      disable:
+        - fieldalignment
+      enable-all: true
+    nolintlint:
+      require-specific: true
+    staticcheck:
+      dot-import-whitelist:
+        - github.com/majewsky/gg/option
+        - github.com/onsi/ginkgo/v2
+        - github.com/onsi/gomega
+    usestdlibvars:
+      http-method: true
+      http-status-code: true
+      time-weekday: true
+      time-month: true
+      time-layout: true
+      crypto-hash: true
+      default-rpc-path: true
+      sql-isolation-level: true
+      tls-signature-scheme: true
+      constant-kind: true
+    usetesting:
+      os-temp-dir: true
+    whitespace:
+      # Enforce newlines (or comments) after multi-line function signatures.
+      multi-func: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - bodyclose
+        path: _test\.go
+      # It is idiomatic Go to reuse the name 'err' with ':=' for subsequent errors.
+      # Ref: https://go.dev/doc/effective_go#redeclaration
+      - path: (.+)\.go$
+        text: declaration of "err" shadows declaration at
+      - linters:
+          - goconst
+        path: (.+)_test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+
+output:
+  formats:
+    text:
+      # Do not print lines of code with issue.
+      print-issued-lines: false

--- a/README.md
+++ b/README.md
@@ -185,10 +185,10 @@ golang:
 Set `golang.enableVendoring` to `true` if you vendor all dependencies in your repository. With vendoring enabled:
 
 1. The default for `GO_BUILDFLAGS` is set to `-mod vendor`, so that build targets default to using vendored dependencies.
-   This means that building binaries does not require a network connection.
+  This means that building binaries does not require a network connection.
 2. The `make tidy-deps` target is replaced by a `make vendor` target that runs `go mod tidy && go mod verify` just like `make tidy-deps`, but also runs `go
-   mod vendor`.
-   This target can be used to get the vendor directory up-to-date before commits.
+  mod vendor`.
+  This target can be used to get the vendor directory up-to-date before commits.
 
 If `golang.setGoModVersion` is set to `true` then `go.mod` will be automatically updated to the latest version.
 The `ldflags` option can be used to share flags between the Makefile and GoReleaser.

--- a/internal/core/constants.go
+++ b/internal/core/constants.go
@@ -29,7 +29,7 @@ const (
 	CodeqlAnalyzeAction   = "github/codeql-action/analyze@v3"
 	CodeqlAutobuildAction = "github/codeql-action/autobuild@v3"
 
-	GolangciLintAction = "golangci/golangci-lint-action@v6"
+	GolangciLintAction = "golangci/golangci-lint-action@v7"
 	GoreleaserAction   = "goreleaser/goreleaser-action@v6"
 	MisspellAction     = "reviewdog/action-misspell@v1"
 )

--- a/internal/golangcilint/golangci_lint.go
+++ b/internal/golangcilint/golangci_lint.go
@@ -21,195 +21,204 @@ var configTmpl = template.Must(template.New("golangci").Parse(strings.TrimSpace(
 version: "2"
 run:
 	modules-download-mode: {{ .ModDownloadMode }}
-  timeout: {{ .Timeout }} # none by default in v2
+	timeout: {{ .Timeout }} # none by default in v2
 
 formatters:
-  enable:
-    - gofmt
-    - goimports
-  settings:
-    goimports:
-      # Put local imports after 3rd-party packages
-      local-prefixes:
-        - {{ .ModulePath }}
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+	enable:
+		- gofmt
+		- goimports
+	settings:
+		goimports:
+			# Put local imports after 3rd-party packages
+			local-prefixes:
+				- {{ .ModulePath }}
+	exclusions:
+		generated: lax
+		paths:
+			- third_party$
+			- builtin$
+			- examples$
 
 issues:
-  # '0' disables the following options
-  max-issues-per-linter: 0
-  max-same-issues: 0
+	# '0' disables the following options
+	max-issues-per-linter: 0
+	max-same-issues: 0
 
 linters:
-  # Disable all pre-enabled linters and enable them explicitly so that a newer version does not introduce new linters unexpectedly
-  default: none
-  enable:
-    - bodyclose
-    - containedctx
-    - copyloopvar
-    - dupword
-    - durationcheck
-    - errcheck
-    - errname
-    - errorlint
-    - exptostd
-    - forbidigo
-    - ginkgolinter
-    - gocheckcompilerdirectives
-    - goconst
-    - gocritic
-    - gomoddirectives
-    - gosec
-    - govet
-    - ineffassign
-    - intrange
-    - misspell
-    - nilerr
-    - noctx
-    - nolintlint
-    - nosprintfhostport
-    - perfsprint
-    - predeclared
-    - rowserrcheck
-    - sqlclosecheck
-    - staticcheck
-    - unconvert
-    - unparam
-    - unused
-    - usestdlibvars
-    - usetesting
-    - whitespace
-  settings:
-    errcheck:
-      check-type-assertions: false
-      # Report about assignment of errors to blank identifier.
-      check-blank: true
-      # Do not report about not checking of errors in type assertions.
-      # This is not as dangerous as skipping error values because an unchecked type assertion just immediately panics.
-      # We disable this because it makes a ton of useless noise esp. in test code.
-      {{- if .ErrcheckExcludes }}
-      exclude-functions:
-        {{- range .ErrcheckExcludes }}
-        - {{ . }}
-        {{- end }}
-      {{- end }}
-    forbidigo:
-      analyze-types: true # required for pkg:
-      forbid:
-        - pattern: ^ioutil\..*$
-        - pattern: ^http\.DefaultServeMux$
-        - pattern: ^http\.Handle(?:Func)?$
-        - pkg: ^gopkg\.in/square/go-jose\.v2$
-          msg: gopk.in/square/go-jose is archived and has CVEs. Replace it with gopkg.in/go-jose/go-jose.v2
-        - pkg: ^github.com/coreos/go-oidc$
-          msg: github.com/coreos/go-oidc depends on gopkg.in/square/go-jose which has CVEs. Replace it with github.com/coreos/go-oidc/v3
-        - pkg: ^github.com/howeyc/gopass$
-          msg: github.com/howeyc/gopass is archived, use golang.org/x/term instead
-    goconst:
-      min-occurrences: 5
-    gocritic:
-      enabled-checks:
-        - boolExprSimplify
-        - builtinShadow
-        - emptyStringTest
-        - evalOrder
-        - httpNoBody
-        - importShadow
-        - initClause
-        - methodExprCall
-        - paramTypeCombine
-        - preferFilepathJoin
-        - ptrToRefParam
-        - redundantSprint
-        - returnAfterHttpError
-        - stringConcatSimplify
-        - timeExprSimplify
-        - truncateCmp
-        - typeAssertChain
-        - typeUnparen
-        - unnamedResult
-        - unnecessaryBlock
-        - unnecessaryDefer
-        - weakCond
-        - yodaStyleExpr
-    gomoddirectives:
-      replace-allow-list:
-        # for go-pmtud
-        - github.com/mdlayher/arp
-      toolchain-forbidden: true
-      go-version-pattern: 1\.\d+(\.0)?$
-    gosec:
-      excludes:
-        # gosec wants us to set a short ReadHeaderTimeout to avoid Slowloris attacks, but doing so would expose us to Keep-Alive race conditions (see https://iximiuz.com/en/posts/reverse-proxy-http-keep-alive-and-502s/
-        - G112
-        # created file permissions are restricted by umask if necessary
-        - G306
-    govet:
-      disable:
-        - fieldalignment
-      enable-all: true
-    nolintlint:
-      require-specific: true
-    {{- if .MisspellIgnoreWords }}
-    misspell:
-      ignore-words:
-        {{- range .MisspellIgnoreWords }}
-        - {{ . }}
-        {{- end }}
-    {{- end }}
-    staticcheck:
-      dot-import-whitelist:
-        - github.com/majewsky/gg/option
-        - github.com/onsi/ginkgo/v2
-        - github.com/onsi/gomega
-    usestdlibvars:
-      http-method: true
-      http-status-code: true
-      time-weekday: true
-      time-month: true
-      time-layout: true
-      crypto-hash: true
-      default-rpc-path: true
-      sql-isolation-level: true
-      tls-signature-scheme: true
-      constant-kind: true
-    usetesting:
-      os-temp-dir: true
-    whitespace:
-      # Enforce newlines (or comments) after multi-line function signatures.
-      multi-func: true
-  exclusions:
-    generated: lax
-    presets:
-      - comments
-      - common-false-positives
-      - legacy
-      - std-error-handling
-    rules:
-      - linters:
-          - bodyclose
-        path: _test\.go
-      # It is idiomatic Go to reuse the name 'err' with ':=' for subsequent errors.
-      # Ref: https://go.dev/doc/effective_go#redeclaration
-      - path: (.+)\.go$
-        text: declaration of "err" shadows declaration at
-      - linters:
-          - goconst
-        path: (.+)_test\.go
-      {{- if .SkipDirs }}
-      {{- range .SkipDirs }}
-      - path:
-        - {{ . }}
-      {{- end }}
-      {{- end }}
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+	# Disable all pre-enabled linters and enable them explicitly so that a newer version does not introduce new linters unexpectedly
+	default: none
+	enable:
+		- bodyclose
+		- containedctx
+		- copyloopvar
+		- dupword
+		- durationcheck
+		- errcheck
+		- errname
+		- errorlint
+		- exptostd
+		- forbidigo
+		- ginkgolinter
+		- gocheckcompilerdirectives
+		- goconst
+		- gocritic
+		- gomoddirectives
+		- gosec
+		- govet
+		- ineffassign
+		- intrange
+		- misspell
+		- nilerr
+		- noctx
+		- nolintlint
+		- nosprintfhostport
+		- perfsprint
+		- predeclared
+		- rowserrcheck
+		- sqlclosecheck
+		- staticcheck
+		- unconvert
+		- unparam
+		- unused
+		- usestdlibvars
+		- usetesting
+		- whitespace
+	settings:
+		errcheck:
+			check-type-assertions: false
+			# Report about assignment of errors to blank identifier.
+			check-blank: true
+			# Do not report about not checking of errors in type assertions.
+			# This is not as dangerous as skipping error values because an unchecked type assertion just immediately panics.
+			# We disable this because it makes a ton of useless noise esp. in test code.
+			{{- if .ErrcheckExcludes }}
+			exclude-functions:
+				{{- range .ErrcheckExcludes }}
+				- {{ . }}
+				{{- end }}
+			{{- end }}
+		forbidigo:
+			analyze-types: true # required for pkg:
+			forbid:
+				# ioutil package has been deprecated: https://github.com/golang/go/issues/42026
+				- pattern: ^ioutil\..*$
+				# Using http.DefaultServeMux is discouraged because it's a global variable that some packages silently and magically add handlers to (esp. net/http/pprof).
+				# Applications wishing to use http.ServeMux should obtain local instances through http.NewServeMux() instead of using the global default instance.
+				- pattern: ^http\.DefaultServeMux$
+				- pattern: ^http\.Handle(?:Func)?$
+				- pkg: ^gopkg\.in/square/go-jose\.v2$
+					msg: gopk.in/square/go-jose is archived and has CVEs. Replace it with gopkg.in/go-jose/go-jose.v2
+				- pkg: ^github.com/coreos/go-oidc$
+					msg: github.com/coreos/go-oidc depends on gopkg.in/square/go-jose which has CVEs. Replace it with github.com/coreos/go-oidc/v3
+				- pkg: ^github.com/howeyc/gopass$
+					msg: github.com/howeyc/gopass is archived, use golang.org/x/term instead
+		goconst:
+			min-occurrences: 5
+		gocritic:
+			enabled-checks:
+				- boolExprSimplify
+				- builtinShadow
+				- emptyStringTest
+				- evalOrder
+				- httpNoBody
+				- importShadow
+				- initClause
+				- methodExprCall
+				- paramTypeCombine
+				- preferFilepathJoin
+				- ptrToRefParam
+				- redundantSprint
+				- returnAfterHttpError
+				- stringConcatSimplify
+				- timeExprSimplify
+				- truncateCmp
+				- typeAssertChain
+				- typeUnparen
+				- unnamedResult
+				- unnecessaryBlock
+				- unnecessaryDefer
+				- weakCond
+				- yodaStyleExpr
+		gomoddirectives:
+			replace-allow-list:
+				# for go-pmtud
+				- github.com/mdlayher/arp
+			toolchain-forbidden: true
+			go-version-pattern: 1\.\d+(\.0)?$
+		gosec:
+			excludes:
+				# gosec wants us to set a short ReadHeaderTimeout to avoid Slowloris attacks, but doing so would expose us to Keep-Alive race conditions (see https://iximiuz.com/en/posts/reverse-proxy-http-keep-alive-and-502s/
+				- G112
+				# created file permissions are restricted by umask if necessary
+				- G306
+		govet:
+			disable:
+				- fieldalignment
+			enable-all: true
+		nolintlint:
+			require-specific: true
+		{{- if .MisspellIgnoreWords }}
+		misspell:
+			ignore-words:
+				{{- range .MisspellIgnoreWords }}
+				- {{ . }}
+				{{- end }}
+		{{- end }}
+		staticcheck:
+			dot-import-whitelist:
+				- github.com/majewsky/gg/option
+				- github.com/onsi/ginkgo/v2
+				- github.com/onsi/gomega
+		usestdlibvars:
+			http-method: true
+			http-status-code: true
+			time-weekday: true
+			time-month: true
+			time-layout: true
+			crypto-hash: true
+			default-rpc-path: true
+			sql-isolation-level: true
+			tls-signature-scheme: true
+			constant-kind: true
+		usetesting:
+			os-temp-dir: true
+		whitespace:
+			# Enforce newlines (or comments) after multi-line function signatures.
+			multi-func: true
+	exclusions:
+		generated: lax
+		presets:
+			- comments
+			- common-false-positives
+			- legacy
+			- std-error-handling
+		rules:
+			- linters:
+					- bodyclose
+				path: _test\.go
+			# It is idiomatic Go to reuse the name 'err' with ':=' for subsequent errors.
+			# Ref: https://go.dev/doc/effective_go#redeclaration
+			- path: (.+)\.go$
+				text: declaration of "err" shadows declaration at
+			- linters:
+					- goconst
+				path: (.+)_test\.go
+			{{- if .SkipDirs }}
+			{{- range .SkipDirs }}
+			- path:
+				- {{ . }}
+			{{- end }}
+			{{- end }}
+		paths:
+			- third_party$
+			- builtin$
+			- examples$
+
+output:
+  formats:
+    text:
+			# Do not print lines of code with issue.
+      print-issued-lines: false
 `, "\t", "  "))))
 
 type configTmplData struct {

--- a/internal/golangcilint/golangci_lint.go
+++ b/internal/golangcilint/golangci_lint.go
@@ -18,190 +18,198 @@ import (
 )
 
 var configTmpl = template.Must(template.New("golangci").Parse(strings.TrimSpace(strings.ReplaceAll(`
+version: "2"
 run:
-	timeout: {{ .Timeout }} # 1m by default
 	modules-download-mode: {{ .ModDownloadMode }}
+  timeout: {{ .Timeout }} # none by default in v2
 
-output:
-	# Do not print lines of code with issue.
-	print-issued-lines: false
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      # Put local imports after 3rd-party packages
+      local-prefixes:
+        - {{ .ModulePath }}
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
 issues:
-	exclude:
-		# It is idiomatic Go to reuse the name 'err' with ':=' for subsequent errors.
-		# Ref: https://go.dev/doc/effective_go#redeclaration
-		- 'declaration of "err" shadows declaration at'
-	{{- if .SkipDirs }}
-	exclude-dirs:
-		{{- range .SkipDirs }}
-		- {{ . }}
-		{{- end }}
-	{{- end }}
-	exclude-rules:
-		- path: _test\.go
-			linters:
-				- bodyclose
-	# '0' disables the following options.
-	max-issues-per-linter: 0
-	max-same-issues: 0
-
-linters-settings:
-	errcheck:
-		# Report about assignment of errors to blank identifier.
-		check-blank: true
-		# Do not report about not checking of errors in type assertions.
-		# This is not as dangerous as skipping error values because an unchecked type assertion just immediately panics.
-		# We disable this because it makes a ton of useless noise esp. in test code.
-		check-type-assertions: false
-		{{- if .ErrcheckExcludes }}
-		exclude-functions:
-			{{- range .ErrcheckExcludes }}
-			- {{ . }}
-			{{- end }}
-		{{- end }}
-	forbidigo:
-		analyze-types: true # required for pkg:
-		forbid:
-			# ioutil package has been deprecated: https://github.com/golang/go/issues/42026
-			- ^ioutil\..*$
-			# Using http.DefaultServeMux is discouraged because it's a global variable that some packages silently and magically add handlers to (esp. net/http/pprof).
-			# Applications wishing to use http.ServeMux should obtain local instances through http.NewServeMux() instead of using the global default instance.
-			- ^http\.DefaultServeMux$
-			- ^http\.Handle(?:Func)?$
-			# Forbid usage of old and archived square/go-jose
-			- pkg: ^gopkg\.in/square/go-jose\.v2$
-				msg: "gopk.in/square/go-jose is archived and has CVEs. Replace it with gopkg.in/go-jose/go-jose.v2"
-			- pkg: ^github.com/coreos/go-oidc$
-				msg: "github.com/coreos/go-oidc depends on gopkg.in/square/go-jose which has CVEs. Replace it with github.com/coreos/go-oidc/v3"
-
-			- pkg: ^github.com/howeyc/gopass$
-				msg: "github.com/howeyc/gopass is archived, use golang.org/x/term instead"
-	goconst:
-		ignore-tests: true
-		min-occurrences: 5
-	gocritic:
-		enabled-checks:
-			- boolExprSimplify
-			- builtinShadow
-			- emptyStringTest
-			- evalOrder
-			- httpNoBody
-			- importShadow
-			- initClause
-			- methodExprCall
-			- paramTypeCombine
-			- preferFilepathJoin
-			- ptrToRefParam
-			- redundantSprint
-			- returnAfterHttpError
-			- stringConcatSimplify
-			- timeExprSimplify
-			- truncateCmp
-			- typeAssertChain
-			- typeUnparen
-			- unnamedResult
-			- unnecessaryBlock
-			- unnecessaryDefer
-			- weakCond
-			- yodaStyleExpr
-	goimports:
-		# Put local imports after 3rd-party packages.
-		local-prefixes: {{ .ModulePath }}
-	gomoddirectives:
-		go-version-pattern: '1\.\d+(\.0)?$'
-		replace-allow-list:
-			# for go-pmtud
-			- github.com/mdlayher/arp
-		toolchain-forbidden: true
-	gosec:
-		excludes:
-			# gosec wants us to set a short ReadHeaderTimeout to avoid Slowloris attacks, but doing so would expose us to Keep-Alive race conditions (see https://iximiuz.com/en/posts/reverse-proxy-http-keep-alive-and-502s/)
-			- G112
-			# created file permissions are restricted by umask if necessary
-			- G306
-	govet:
-		enable-all: true
-		disable:
-			- fieldalignment
-	nolintlint:
-		require-specific: true
-	{{- if .MisspellIgnoreWords }}
-	misspell:
-		ignore-words:
-			{{- range .MisspellIgnoreWords }}
-			- {{ . }}
-			{{- end }}
-	{{- end }}
-	stylecheck:
-		dot-import-whitelist:
-			- github.com/majewsky/gg/option
-			- github.com/onsi/ginkgo/v2
-			- github.com/onsi/gomega
-	usestdlibvars:
-		constant-kind: true
-		crypto-hash: true
-		default-rpc-path: true
-		http-method: true
-		http-status-code: true
-		sql-isolation-level: true
-		time-layout: true
-		time-month: true
-		time-weekday: true
-		tls-signature-scheme: true
-	usetesting:
-		os-temp-dir: true
-	whitespace:
-		# Enforce newlines (or comments) after multi-line function signatures.
-		multi-func: true
+  # '0' disables the following options
+  max-issues-per-linter: 0
+  max-same-issues: 0
 
 linters:
-	# We use 'disable-all' and enable linters explicitly so that a newer version
-	# does not introduce new linters unexpectedly.
-	disable-all: true
-	enable:
-		- bodyclose
-		- containedctx
-		- copyloopvar
-		- dupword
-		- durationcheck
-		- errcheck
-		- errname
-		- errorlint
-  {{- if lt .GoMinorVersion 22 }}
-		- exportloopref
-  {{- end }}
-		- exptostd
-		- forbidigo
-		- ginkgolinter
-		- gocheckcompilerdirectives
-		- goconst
-		- gocritic
-		- gofmt
-		- goimports
-		- gomoddirectives
-		- gosec
-		- gosimple
-		- govet
-		- ineffassign
-		- intrange
-		- misspell
-		- nilerr
-		- noctx
-		- nolintlint
-		- nosprintfhostport
-		- perfsprint
-		- predeclared
-		- rowserrcheck
-		- sqlclosecheck
-		- staticcheck
-		- stylecheck
-		- typecheck
-		- unconvert
-		- unparam
-		- unused
-		- usestdlibvars
-		- usetesting
-		- whitespace
+  # Disable all pre-enabled linters and enable them explicitly so that a newer version does not introduce new linters unexpectedly
+  default: none
+  enable:
+    - bodyclose
+    - containedctx
+    - copyloopvar
+    - dupword
+    - durationcheck
+    - errcheck
+    - errname
+    - errorlint
+    - exptostd
+    - forbidigo
+    - ginkgolinter
+    - gocheckcompilerdirectives
+    - goconst
+    - gocritic
+    - gomoddirectives
+    - gosec
+    - govet
+    - ineffassign
+    - intrange
+    - misspell
+    - nilerr
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    - perfsprint
+    - predeclared
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - usetesting
+    - whitespace
+  settings:
+    errcheck:
+      check-type-assertions: false
+      # Report about assignment of errors to blank identifier.
+      check-blank: true
+      # Do not report about not checking of errors in type assertions.
+      # This is not as dangerous as skipping error values because an unchecked type assertion just immediately panics.
+      # We disable this because it makes a ton of useless noise esp. in test code.
+      {{- if .ErrcheckExcludes }}
+      exclude-functions:
+        {{- range .ErrcheckExcludes }}
+        - {{ . }}
+        {{- end }}
+      {{- end }}
+    forbidigo:
+      analyze-types: true # required for pkg:
+      forbid:
+        - pattern: ^ioutil\..*$
+        - pattern: ^http\.DefaultServeMux$
+        - pattern: ^http\.Handle(?:Func)?$
+        - pkg: ^gopkg\.in/square/go-jose\.v2$
+          msg: gopk.in/square/go-jose is archived and has CVEs. Replace it with gopkg.in/go-jose/go-jose.v2
+        - pkg: ^github.com/coreos/go-oidc$
+          msg: github.com/coreos/go-oidc depends on gopkg.in/square/go-jose which has CVEs. Replace it with github.com/coreos/go-oidc/v3
+        - pkg: ^github.com/howeyc/gopass$
+          msg: github.com/howeyc/gopass is archived, use golang.org/x/term instead
+    goconst:
+      min-occurrences: 5
+    gocritic:
+      enabled-checks:
+        - boolExprSimplify
+        - builtinShadow
+        - emptyStringTest
+        - evalOrder
+        - httpNoBody
+        - importShadow
+        - initClause
+        - methodExprCall
+        - paramTypeCombine
+        - preferFilepathJoin
+        - ptrToRefParam
+        - redundantSprint
+        - returnAfterHttpError
+        - stringConcatSimplify
+        - timeExprSimplify
+        - truncateCmp
+        - typeAssertChain
+        - typeUnparen
+        - unnamedResult
+        - unnecessaryBlock
+        - unnecessaryDefer
+        - weakCond
+        - yodaStyleExpr
+    gomoddirectives:
+      replace-allow-list:
+        # for go-pmtud
+        - github.com/mdlayher/arp
+      toolchain-forbidden: true
+      go-version-pattern: 1\.\d+(\.0)?$
+    gosec:
+      excludes:
+        # gosec wants us to set a short ReadHeaderTimeout to avoid Slowloris attacks, but doing so would expose us to Keep-Alive race conditions (see https://iximiuz.com/en/posts/reverse-proxy-http-keep-alive-and-502s/
+        - G112
+        # created file permissions are restricted by umask if necessary
+        - G306
+    govet:
+      disable:
+        - fieldalignment
+      enable-all: true
+    nolintlint:
+      require-specific: true
+    {{- if .MisspellIgnoreWords }}
+    misspell:
+      ignore-words:
+        {{- range .MisspellIgnoreWords }}
+        - {{ . }}
+        {{- end }}
+    {{- end }}
+    staticcheck:
+      dot-import-whitelist:
+        - github.com/majewsky/gg/option
+        - github.com/onsi/ginkgo/v2
+        - github.com/onsi/gomega
+    usestdlibvars:
+      http-method: true
+      http-status-code: true
+      time-weekday: true
+      time-month: true
+      time-layout: true
+      crypto-hash: true
+      default-rpc-path: true
+      sql-isolation-level: true
+      tls-signature-scheme: true
+      constant-kind: true
+    usetesting:
+      os-temp-dir: true
+    whitespace:
+      # Enforce newlines (or comments) after multi-line function signatures.
+      multi-func: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - bodyclose
+        path: _test\.go
+      # It is idiomatic Go to reuse the name 'err' with ':=' for subsequent errors.
+      # Ref: https://go.dev/doc/effective_go#redeclaration
+      - path: (.+)\.go$
+        text: declaration of "err" shadows declaration at
+      - linters:
+          - goconst
+        path: (.+)_test\.go
+      {{- if .SkipDirs }}
+      {{- range .SkipDirs }}
+      - path:
+        - {{ . }}
+      {{- end }}
+      {{- end }}
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 `, "\t", "  "))))
 
 type configTmplData struct {

--- a/internal/goreleaser/RELEASE.md
+++ b/internal/goreleaser/RELEASE.md
@@ -10,40 +10,40 @@ process. Follow the instructions below for creating a new release.
 
 1. Ensure local `master` branch is up to date with `origin/master`:
 
-   ```sh
-   git fetch --all --tags
-   ```
+  ```sh
+  git fetch --all --tags
+  ```
 
 2. Ensure all checks are passing:
 
-   ```sh
-   make check
-   ```
+  ```sh
+  make check
+  ```
 
 3. Update the [`CHANGELOG`](./CHANGELOG.md).
-   Make sure that the format is consistent especially the version heading.
-   We follow [semantic versioning][semver] for our releases.
+  Make sure that the format is consistent especially the version heading.
+  We follow [semantic versioning][semver] for our releases.
 
-   You can check if the file format is correct by running [`release-info`][release-info] for the new version:
+  You can check if the file format is correct by running [`release-info`][release-info] for the new version:
 
-   ```sh
-   go install github.com/sapcc/go-bits/tools/release-info@latest
-   release-info CHANGELOG.md X.Y.Z
-   ```
+  ```sh
+  go install github.com/sapcc/go-bits/tools/release-info@latest
+  release-info CHANGELOG.md X.Y.Z
+  ```
 
-   where `X.Y.Z` is the version that you are planning to release.
+  where `X.Y.Z` is the version that you are planning to release.
 
 4. Commit the updated changelog with message: `Release <version>`
 5. Create and push a new Git tag:
 
-   ```sh
-   git tag vX.Y.Z
-   git push
-   git push --tags
-   ```
+  ```sh
+  git tag vX.Y.Z
+  git push
+  git push --tags
+  ```
 
-   > [!IMPORTANT]
-   > Tags are prefixed with `v` and the GitHub release workflow is triggered for tags that match the `v[0-9]+.[0-9]+.[0-9]+` [gh-pattern].
+  > [!IMPORTANT]
+  > Tags are prefixed with `v` and the GitHub release workflow is triggered for tags that match the `v[0-9]+.[0-9]+.[0-9]+` [gh-pattern].
 
 [release-info]: https://github.com/sapcc/go-bits/tree/master/tools/release-info
 [semver]: https://semver.org/spec/v2.0.0.html

--- a/internal/goreleaser/goreleaser.go
+++ b/internal/goreleaser/goreleaser.go
@@ -18,50 +18,50 @@ import (
 	"github.com/sapcc/go-bits/must"
 )
 
-const goreleaserTemplate = `# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+var goreleaserTemplate = strings.ReplaceAll(`# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 version: 2
 
 archives:
-  - name_template: '%[1]s'%[2]s
-    format_overrides:
-      - goos: windows
-        format: zip
-    files:%[3]s
+	- name_template: '%[1]s'%[2]s
+		format_overrides:
+			- goos: windows
+				format: zip
+		files:%[3]s
 
 checksum:
-  name_template: "checksums.txt"
+	name_template: "checksums.txt"
 
 builds:
-  - binary: '%[4]s'
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-      - windows
-      - darwin
-    goarch:
-      - amd64
-      - arm64
-    ignore:
-      - goos: windows
-        goarch: arm64
-    ldflags:
-      - -s -w
-      - -X github.com/sapcc/go-api-declarations/bininfo.binName=%[5]s
-      - -X github.com/sapcc/go-api-declarations/bininfo.version={{ .Version }}
-      - -X github.com/sapcc/go-api-declarations/bininfo.commit={{ .FullCommit  }}
-      - -X github.com/sapcc/go-api-declarations/bininfo.buildDate={{ .CommitDate }} # use CommitDate instead of Date for reproducibility%[6]s
-    main: %[7]s
-    # Set the modified timestamp on the output binary to ensure that builds are reproducible.
-    mod_timestamp: "{{ .CommitTimestamp }}"
+	- binary: '%[4]s'
+		env:
+			- CGO_ENABLED=0
+		goos:
+			- linux
+			- windows
+			- darwin
+		goarch:
+			- amd64
+			- arm64
+		ignore:
+			- goos: windows
+				goarch: arm64
+		ldflags:
+			- -s -w
+			- -X github.com/sapcc/go-api-declarations/bininfo.binName=%[5]s
+			- -X github.com/sapcc/go-api-declarations/bininfo.version={{ .Version }}
+			- -X github.com/sapcc/go-api-declarations/bininfo.commit={{ .FullCommit  }}
+			- -X github.com/sapcc/go-api-declarations/bininfo.buildDate={{ .CommitDate }} # use CommitDate instead of Date for reproducibility%[6]s
+		main: %[7]s
+		# Set the modified timestamp on the output binary to ensure that builds are reproducible.
+		mod_timestamp: "{{ .CommitTimestamp }}"
 
 release:
-  make_latest: true
-  prerelease: auto
+	make_latest: true
+	prerelease: auto
 %[8]s
 snapshot:
-  version_template: "{{ .Tag }}-next"
-`
+	version_template: "{{ .Tag }}-next"
+`, "\t", "  ")
 
 //go:embed RELEASE.md
 var releaseMD string
@@ -82,16 +82,17 @@ func RenderConfig(cfg core.Configuration) {
 	}
 
 	if cfg.GoReleaser.Format != "" {
-		format = `
-    format: ` + cfg.GoReleaser.Format
+		format = strings.ReplaceAll(`
+		format: `, "\t", "  ") + cfg.GoReleaser.Format
 	}
 
 	var files string
 	if cfg.GoReleaser.Files == nil {
-		files = `
-      - CHANGELOG.md
-      - LICENSE
-      - README.md`
+		files = strings.ReplaceAll(`
+			- CHANGELOG.md
+			- LICENSE
+			- README.md`,
+			"\t", "  ")
 	} else {
 		for _, file := range *cfg.GoReleaser.Files {
 			files += "      - " + file
@@ -113,7 +114,7 @@ func RenderConfig(cfg core.Configuration) {
 		for _, name := range names {
 			value := cfg.Golang.LdFlags[name]
 			ldflags += fmt.Sprintf(`
-      - %s={{.Env.%s}}`, name, value)
+			- %s={{.Env.%s}}`, name, value)
 		}
 	}
 
@@ -123,12 +124,12 @@ func RenderConfig(cfg core.Configuration) {
 			logg.Fatal("Metadata.URL is not a parsable URL: %w", err)
 		}
 
-		githubURLs = fmt.Sprintf(`
+		githubURLs = fmt.Sprintf(strings.ReplaceAll(`
 github_urls:
-  api: https://%[1]s/api/v3/
-  upload: https://%[1]s/api/uploads/
-  download: https://%[1]s/
-`, metadataURL.Host)
+	api: https://%[1]s/api/v3/
+	upload: https://%[1]s/api/uploads/
+	download: https://%[1]s/
+`, "\t", "  "), metadataURL.Host)
 	}
 
 	goreleaserFile := fmt.Sprintf(goreleaserTemplate, nameTemplate, format, files, binaryName, cfg.Binaries[0].Name, ldflags, cfg.Binaries[0].FromPackage, githubURLs)

--- a/internal/makefile/editorconfig
+++ b/internal/makefile/editorconfig
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: SAP SE
+# SPDX-License-Identifier: Apache-2.0
+
+root = true
+
+[*]
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[{Makefile,go.mod,go.sum,*.go}]
+indent_style = tab
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{LICENSE,LICENSES/*,vendor/**}]
+charset = unset
+end_of_line = unset
+indent_size = unset
+indent_style = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset

--- a/internal/makefile/makefile.go
+++ b/internal/makefile/makefile.go
@@ -18,6 +18,9 @@ import (
 	"github.com/sapcc/go-makefile-maker/internal/golang"
 )
 
+//go:embed editorconfig
+var editorconfig []byte
+
 //go:embed REUSE.toml
 var reuseConfig []byte
 
@@ -434,6 +437,8 @@ endif
 				reuseConfigFile := "REUSE.toml"
 				must.Succeed(os.WriteFile(reuseConfigFile, reuseConfig, 0o666))
 			}
+
+			must.Succeed(os.WriteFile(".editorconfig", editorconfig, 0o666))
 
 			licenseRulesFile := ".license-scan-rules.json"
 			must.Succeed(os.WriteFile(licenseRulesFile, licenseRules, 0o666))

--- a/internal/nix/nix-shell.go
+++ b/internal/nix/nix-shell.go
@@ -16,7 +16,7 @@ import (
 )
 
 func RenderShell(cfg core.Configuration, sr golang.ScanResult, renderGoreleaserConfig bool) {
-	nixShellTemplate := `# Copyright 2024 SAP SE
+	nixShellTemplate := strings.ReplaceAll(`# Copyright 2024 SAP SE
 # SPDX-License-Identifier: Apache-2.0
 
 { pkgs ? import <nixpkgs> { } }:
@@ -24,13 +24,13 @@ func RenderShell(cfg core.Configuration, sr golang.ScanResult, renderGoreleaserC
 with pkgs;
 
 mkShell {
-  nativeBuildInputs = [
+	nativeBuildInputs = [
 %s
-    # keep this line if you use bash
-    bashInteractive
-  ];
+		# keep this line if you use bash
+		bashInteractive
+	];
 }
-`
+`, "\t", "  ")
 
 	goVersionSlice := strings.Split(core.DefaultGoVersion, ".")
 	goPackage := fmt.Sprintf("go_%s_%s", goVersionSlice[0], goVersionSlice[1])
@@ -71,15 +71,15 @@ mkShell {
 	nixShellFile := fmt.Sprintf(nixShellTemplate, packageList)
 	must.Succeed(os.WriteFile("shell.nix", []byte(nixShellFile), 0666))
 
-	must.Succeed(os.WriteFile(".envrc", []byte(`#!/usr/bin/env bash
+	must.Succeed(os.WriteFile(".envrc", []byte(strings.ReplaceAll(`#!/usr/bin/env bash
 # SPDX-FileCopyrightText: 2019–2020 Target, Copyright 2021 The Nix Community
 # SPDX-License-Identifier: Apache-2.0
 if type -P lorri &>/dev/null; then
-  eval "$(lorri direnv)"
+	eval "$(lorri direnv)"
 elif type -P nix &>/dev/null; then
-  use nix
+	use nix
 else
-  echo "Found no nix binary. Skipping activating nix-shell..."
+	echo "Found no nix binary. Skipping activating nix-shell..."
 fi
-`), 0666))
+`, "\t", "  ")), 0666))
 }


### PR DESCRIPTION
The default timeout got removed. Not sure if we want to keep it or remove it entirely like done now.

also see https://github.com/sapcc/keppel/pull/512