### PR TITLE
fix: golangci-lint skip-dirs in config file

### DIFF
--- a/internal/golangcilint/golangci_lint.go
+++ b/internal/golangcilint/golangci_lint.go
@@ -203,16 +203,13 @@ linters:
 			- linters:
 					- goconst
 				path: (.+)_test\.go
-			{{- if .SkipDirs }}
-			{{- range .SkipDirs }}
-			- path:
-				- {{ . }}
-			{{- end }}
-			{{- end }}
 		paths:
 			- third_party$
 			- builtin$
 			- examples$
+			{{- range .SkipDirs }}
+			- {{ . }}
+			{{- end }}
 
 output:
   formats:


### PR DESCRIPTION
In v2 of golangci-lint the `run.skip-dirs` config has been moved to `linters.exclusions.paths`. However the config was (mistakenly) added to the `linters.exclusions.rules` instead which is fixed by this patch.