### PR TITLE
fix fatal error in REUSE.toml generation without deps

### DIFF
--- a/internal/reuse/reuse.go
+++ b/internal/reuse/reuse.go
@@ -64,6 +64,10 @@ func RenderConfig(cfg core.Configuration, sr golang.ScanResult) {
 		}
 
 		for _, dependencyString := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+			dependencyString = strings.TrimSpace(dependencyString)
+			if dependencyString == "" {
+				continue
+			}
 			var dep struct {
 				Name    string `json:"name"`
 				License string `json:"license"`


### PR DESCRIPTION
When there are no library dependencies, go-licence-detector will print an empty result, and thus the loop will run once on the empty string, which is not a valid input for json.Marshal.