### PR TITLE
add dockerfile.extraBuildPackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ dockerfile:
     - |
       FROM ghcr.io/foobar/big-toolbox AS toolbox
       RUN toolbox-cmd
+  extraBuildPackages:
+    - linux-headers
   extraDirectives:
     - 'LABEL mylabel=myvalue'
     - 'COPY --from=toolbox /bin/fancytool /usr/bin/fancytool'
@@ -175,6 +177,7 @@ With [go-api-declarations](https://github.com/sapcc/go-api-declarations)'s [`bin
 
 * `entrypoint` allows overwriting the final entrypoint.
 * `extraBuildStages` prepends additional build stages at the top of the Dockerfile. This is useful for bringing in precompiled assets from other images, or if a non-Go compilation step is required.
+* `extraBuildPackages` installs extra Alpine packages in the Docker layer where `make install` is executed. We always install `ca-certificates`, `gcc`, `git`, `make` and `musl-dev`.
 * `extraDirectives` appends additional directives near the end of the Dockerfile.
 * `extraIgnores` appends entries in `.dockerignore` to the default ones.
 * `extraPackages` installs extra Alpine packages in the final Docker layer. `ca-certificates` is always installed.

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -212,14 +212,15 @@ type RenovateConfig struct {
 
 // DockerfileConfig appears in type Configuration.
 type DockerfileConfig struct {
-	Enabled          bool     `yaml:"enabled"`
-	Entrypoint       []string `yaml:"entrypoint"`
-	ExtraBuildStages []string `yaml:"extraBuildStages"`
-	ExtraDirectives  []string `yaml:"extraDirectives"`
-	ExtraIgnores     []string `yaml:"extraIgnores"`
-	ExtraPackages    []string `yaml:"extraPackages"`
-	RunAsRoot        bool     `yaml:"runAsRoot"`
-	WithLinkerdAwait bool     `yaml:"withLinkerdAwait"`
+	Enabled            bool     `yaml:"enabled"`
+	Entrypoint         []string `yaml:"entrypoint"`
+	ExtraBuildPackages []string `yaml:"extraBuildPackages"`
+	ExtraBuildStages   []string `yaml:"extraBuildStages"`
+	ExtraDirectives    []string `yaml:"extraDirectives"`
+	ExtraIgnores       []string `yaml:"extraIgnores"`
+	ExtraPackages      []string `yaml:"extraPackages"`
+	RunAsRoot          bool     `yaml:"runAsRoot"`
+	WithLinkerdAwait   bool     `yaml:"withLinkerdAwait"`
 }
 
 type ControllerGen struct {

--- a/internal/dockerfile/Dockerfile.tmpl
+++ b/internal/dockerfile/Dockerfile.tmpl
@@ -12,7 +12,7 @@
 
 FROM golang:{{ .Constants.DefaultGoVersion }}-alpine{{ .Constants.DefaultAlpineImage }} AS builder
 
-RUN apk add --no-cache --no-progress ca-certificates gcc git make musl-dev
+RUN apk add --no-cache --no-progress ca-certificates gcc git make musl-dev {{- range $dcfg.ExtraBuildPackages }} {{.}}{{ end }}
 
 COPY . /src
 ARG BININFO_BUILD_DATE BININFO_COMMIT_HASH BININFO_VERSION # provided to 'make install'


### PR DESCRIPTION
Surveyor needs to be able to `apk add linux-headers` in the builder stage.