### PR TITLE
remove license-scan-override for nxos-gnmi-go

### DIFF
--- a/.license-scan-overrides.jsonl
+++ b/.license-scan-overrides.jsonl
@@ -7,4 +7,3 @@
 {"name": "github.com/xeipuuv/gojsonpointer", "licenceType": "Apache-2.0"}
 {"name": "github.com/xeipuuv/gojsonreference", "licenceType": "Apache-2.0"}
 {"name": "github.com/xeipuuv/gojsonschema", "licenceType": "Apache-2.0"}
-{"name": "github.wdf.sap.corp/cc/nxos-gnmi-go", "licenceType": "Apache-2.0"}

--- a/internal/makefile/license-scan-overrides.jsonl
+++ b/internal/makefile/license-scan-overrides.jsonl
@@ -7,4 +7,3 @@
 {"name": "github.com/xeipuuv/gojsonpointer", "licenceType": "Apache-2.0"}
 {"name": "github.com/xeipuuv/gojsonreference", "licenceType": "Apache-2.0"}
 {"name": "github.com/xeipuuv/gojsonschema", "licenceType": "Apache-2.0"}
-{"name": "github.wdf.sap.corp/cc/nxos-gnmi-go", "licenceType": "Apache-2.0"}


### PR DESCRIPTION
We internally merged that repository with the one of the project, such that we don't have the need for declaring its license anymore.