### PR TITLE
Speed up docker build with cache mounts

### DIFF
--- a/internal/dockerfile/Dockerfile.tmpl
+++ b/internal/dockerfile/Dockerfile.tmpl
@@ -16,7 +16,9 @@ RUN apk add --no-cache --no-progress ca-certificates gcc git make musl-dev {{- r
 
 COPY . /src
 ARG BININFO_BUILD_DATE BININFO_COMMIT_HASH BININFO_VERSION # provided to 'make install'
-RUN make -C /src install PREFIX=/pkg GOTOOLCHAIN=local{{ if .Config.Golang.EnableVendoring }} GO_BUILDFLAGS='-mod vendor'{{ end }}
+RUN --mount=type=cache,target=/go/pkg/mod \
+	--mount=type=cache,target=/root/.cache/go-build \
+  make -C /src install PREFIX=/pkg GOTOOLCHAIN=local{{ if .Config.Golang.EnableVendoring }} GO_BUILDFLAGS='-mod vendor'{{ end }}
 
 ################################################################################
 


### PR DESCRIPTION
With cache mounts the time for re-running the build step after a file changes can be substanatially improved.

See https://docs.docker.com/build/cache/optimize/#use-cache-mounts

- `/go/pkg/mod stores`: **Downloaded Go modules** Prevents redownloading dependencies (like github.com/foo/bar).
- `/root/.cache/go-build`: **Compiled object files** Caches compiled packages (build artifacts), so Go can skip recompiling unchanged code.