### PR TITLE
Refactor license header handling: simplify and ensure consistent form

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,17 @@ vendor-compat: FORCE
 
 license-headers: FORCE install-addlicense
 	@printf "\e[1;36m>> addlicense (for license headers on source code files)\e[0m\n"
-	@printf "%s\0" $(patsubst $(shell awk '$$1 == "module" {print $$2}' go.mod)%,.%/*.go,$(shell go list ./...)) | $(XARGS) -0 -I{} bash -c 'year="$$(grep 'Copyright' {} | head -n1 | grep -E -o '"'"'[0-9]{4}(-[0-9]{4})?'"'"')"; gawk -i inplace '"'"'{if (display) {print} else {!/^\/\*/ && !/^\*/}}; {if (!display && $$0 ~ /^(package |$$)/) {display=1} else { }}'"'"' {}; addlicense -c "SAP SE or an SAP affiliate company" -s=only -y "$$year" -- {}; $(SED) -i '"'"'1s+// Copyright +// SPDX-FileCopyrightText: +'"'"' {}'
+	@printf "%s\0" $(patsubst $(shell awk '$$1 == "module" {print $$2}' go.mod)%,.%/*.go,$(shell go list ./...)) | $(XARGS) -0 -I{} bash -c 'set -x; \
+		# Try to get the year from the Copyright line \
+		year=$$(grep "Copyright" {} | head -n1 | grep -E -o "[0-9]{4}(-[0-9]{4})?"); \
+		# If year is empty, set it to 2024 \
+		if [ -z "$$year" ]; then \
+			year="2024"; \
+		fi; \
+		# Add license header using addlicense tool \
+		addlicense -c "SAP SE or an SAP affiliate company" -s=only -y "$$year" -- {}; \
+		# Replace the Copyright line with SPDX-FileCopyrightText \
+		$(SED) -i "1s+// Copyright +// SPDX-FileCopyrightText: +" {};'
 	@printf "\e[1;36m>> reuse annotate (for license headers on other files)\e[0m\n"
 	@reuse lint -j | jq -r '.non_compliant.missing_licensing_info[]' | grep -vw vendor | $(XARGS) reuse annotate -c 'SAP SE or an SAP affiliate company' -l Apache-2.0 --skip-unrecognised
 	@printf "\e[1;36m>> reuse download --all\e[0m\n"


### PR DESCRIPTION
### Description:
This PR refines the logic for adding and replacing license headers in source code files. Specifically, it removes the handling of non-SPDX comments and simplifies the logic to:

- Add a SPDX license header at the top of the file if it does not already exist.
- Replace any `// Copyright` line with `// SPDX-FileCopyrightText:` at the top of the file (old logic).
- If there is comments don't delete those comments and just replace the SPDX headers at the top.
- If the copyright year is missing, it defaults to `2024`.

### Changes:
- Removed the logic to remove non-SPDX comments and move SPDX headers.
- Simplified the process to only add the license header if missing or replace `// Copyright` with `// SPDX-FileCopyrightText:`.

### Why:
- When there is no SPDX comments it removes the `package {x}` line from the top.
- To ensure consistent header formatting and correct year assignment without affecting other comments.
