### PR TITLE
Update editorconfig to not set indent_size for *.go files

### DIFF
--- a/internal/makefile/editorconfig
+++ b/internal/makefile/editorconfig
@@ -12,6 +12,7 @@ indent_size = 2
 
 [{Makefile,go.mod,go.sum,*.go}]
 indent_style = tab
+indent_size = unset
 
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
It inherits `indent_size = 2` from `[*]` otherwise. An alternative could be to set it to 4, but given it's individual user preference, should rather be left unset.