### PR TITLE
Update dockerignore.tmpl to include go.work by default

### DIFF
--- a/internal/dockerfile/dockerignore.tmpl
+++ b/internal/dockerfile/dockerignore.tmpl
@@ -1,28 +1,29 @@
 # SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company
 # SPDX-License-Identifier: Apache-2.0
 
-/.dockerignore
 .DS_Store
+/*.env*
+/.dockerignore
 # TODO: uncomment when applications no longer use git to get version information
 #.git/
 /.github/
 /.gitignore
-/.goreleaser.yml
-/*.env*
 /.golangci.yaml
+/.goreleaser.yml
 /.vscode/
-/build/
 /CONTRIBUTING.md
 /Dockerfile
-/docs/
 /LICENSE*
 /Makefile.maker.yaml
 /README.md
+/build/
+/docs/
+/go.work
+/go.work.sum
 /report.html
 /shell.nix
 /testing/
-/go.work
-/go.work.sum
+
 {{- range .ExtraIgnores }}
 {{ . }}
 {{- end }}

--- a/internal/dockerfile/dockerignore.tmpl
+++ b/internal/dockerfile/dockerignore.tmpl
@@ -21,6 +21,8 @@
 /report.html
 /shell.nix
 /testing/
+/go.work
+/go.work.sum
 {{- range .ExtraIgnores }}
 {{ . }}
 {{- end }}


### PR DESCRIPTION
[Workspace files](https://go.dev/ref/mod#workspaces) are generic enough to ignore during docker build by default.