### PR TITLE
Allow custom branch name in release docs

### DIFF
--- a/internal/goreleaser/RELEASE.md.tmpl
+++ b/internal/goreleaser/RELEASE.md.tmpl
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 We use [GoReleaser][goreleaser] and GitHub workflows for automating the release
 process. Follow the instructions below for creating a new release.
 
-1. Ensure local `master` branch is up to date with `origin/master`:
+1. Ensure local `{{ .branch }}` branch is up to date with `origin/{{ .branch }}`:
 
   ```sh
   git fetch --all --tags

--- a/internal/goreleaser/goreleaser.go
+++ b/internal/goreleaser/goreleaser.go
@@ -17,8 +17,8 @@ import (
 )
 
 var (
-	//go:embed RELEASE.md
-	releaseMD string
+	//go:embed RELEASE.md.tmpl
+	releaseMDTemplate string
 
 	//go:embed goreleaser.yaml.tmpl
 	goreleaserTemplate string
@@ -61,6 +61,11 @@ func RenderConfig(cfg core.Configuration) {
 		}
 	}
 
+	branch := "master"
+	if cfg.GitHubWorkflow != nil && cfg.GitHubWorkflow.Global.DefaultBranch != "" {
+		branch = cfg.GitHubWorkflow.Global.DefaultBranch
+	}
+
 	must.Succeed(util.WriteFileFromTemplate(".goreleaser.yaml", goreleaserTemplate, map[string]any{
 		"nameTemplate": nameTemplate,
 		"format":       cfg.GoReleaser.Format,
@@ -71,5 +76,7 @@ func RenderConfig(cfg core.Configuration) {
 		"fromPackage":  cfg.Binaries[0].FromPackage,
 		"githubDomain": metadataURL,
 	}))
-	must.Succeed(util.WriteFile("RELEASE.md", []byte(releaseMD)))
+	must.Succeed(util.WriteFileFromTemplate("RELEASE.md", releaseMDTemplate, map[string]any{
+		"branch": branch,
+	}))
 }


### PR DESCRIPTION
Instead of hard coding the branch name inside of the release docs to `master` this patch attempts to infer the branch name from the default branch name and will template the final release docs.