### PR TITLE
ghworkflow: do not derive go-version from go.mod

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -139,8 +139,8 @@ type GithubWorkflowConfiguration struct {
 	// These global-level settings are applicable for all workflows. They are
 	// superseded by their workflow-level counterpart(s).
 	Global struct {
-		DefaultBranch string `yaml:"defaultBranch"`
-		GoVersion     string `yaml:"goVersion"`
+		DefaultBranch string         `yaml:"defaultBranch"`
+		GoVersion     Option[string] `yaml:"goVersion"`
 	} `yaml:"global"`
 
 	CI                  CIWorkflowConfig             `yaml:"ci"`

--- a/internal/ghworkflow/render.go
+++ b/internal/ghworkflow/render.go
@@ -32,7 +32,7 @@ func Render(cfg core.Configuration, sr golang.ScanResult) {
 	must.Succeed(os.RemoveAll(filepath.Join(workflowDir, "spell.yaml")))
 
 	// TODO: checking on GoVersion is only an aid until we can properly detect rust applications
-	if cfg.GitHubWorkflow.Global.GoVersion != "" {
+	if sr.GoVersion != "" {
 		checksWorkflow(cfg)
 		ciWorkflow(cfg, sr)
 		codeQLWorkflow(cfg)

--- a/internal/ghworkflow/utils.go
+++ b/internal/ghworkflow/utils.go
@@ -74,7 +74,7 @@ func baseJobWithGo(name string, cfg core.Configuration) job {
 		Name: "Set up Go",
 		Uses: core.SetupGoAction,
 		With: map[string]any{
-			"go-version":   cfg.GitHubWorkflow.Global.GoVersion,
+			"go-version":   cfg.GitHubWorkflow.Global.GoVersion.UnwrapOr(core.DefaultGoVersion),
 			"check-latest": true,
 		},
 	})

--- a/main.go
+++ b/main.go
@@ -112,18 +112,6 @@ func main() {
 	// Render GitHub workflows
 	if cfg.GitHubWorkflow != nil {
 		logg.Debug("rendering GitHub Actions workflows")
-		// consider different fallbacks when no explicit go version is set
-		if cfg.GitHubWorkflow.Global.GoVersion == "" {
-			// default to the version in go.mod
-			goVersion := sr.GoVersion
-
-			// overwrite it, we want to use the latest go version
-			if cfg.Golang.SetGoModVersion {
-				goVersion = core.DefaultGoVersion
-			}
-
-			cfg.GitHubWorkflow.Global.GoVersion = goVersion
-		}
 		ghworkflow.Render(cfg, sr)
 	}
 


### PR DESCRIPTION
It does not make any sense at all to rely on `setGoModVersion` in the logic here.

But the current situation is broken for `setGoModVersion = false`: When using the Go version from the go statement in go.mod, we will never get any patch upgrades, and thus we get an edit war between Renovate updating Go 1.x.0 -> 1.x.y in go-version configs of workflows, and go-makefile-maker reverting this change.

This change applies the logic from `setGoModVersion = true`: We always run GitHub workflows with the newest Go version (as maintained in `core.DefaultGoVersion`).