### PR TITLE
Invoke matching version of ginkgo using go run instead of global version

### DIFF
--- a/internal/makefile/makefile.go
+++ b/internal/makefile/makefile.go
@@ -127,16 +127,6 @@ endif
 		prepareStaticRecipe = append(prepareStaticRecipe, "install-shellcheck")
 	}
 
-	if sr.UseGinkgo {
-		prepare.addRule(rule{
-			description: "Install ginkgo required when using it as test runner. This is used in CI before dropping privileges, you should probably install all the tools using your package manager",
-			phony:       true,
-			target:      "install-ginkgo",
-			recipe:      installTool("ginkgo", "github.com/onsi/ginkgo/v2/ginkgo@latest"),
-		})
-		prepareStaticRecipe = append(prepareStaticRecipe, "install-ginkgo")
-	}
-
 	if isSAPCC {
 		if isGolang {
 			prepare.addRule(rule{
@@ -385,8 +375,7 @@ endif
 
 		testRunner := "go test -shuffle=on -p 1 -coverprofile=$@"
 		if sr.UseGinkgo {
-			testRunner = "ginkgo run --randomize-all -output-dir=build"
-			testRule.prerequisites = append(testRule.prerequisites, "install-ginkgo")
+			testRunner = "go run github.com/onsi/ginkgo/v2/ginkgo run --randomize-all -output-dir=build"
 		}
 		goTest := fmt.Sprintf(`%s $(GO_BUILDFLAGS) -ldflags '%s $(GO_LDFLAGS)' -covermode=count -coverpkg=$(subst $(space),$(comma),$(GO_COVERPKGS)) $(GO_TESTPKGS)`,
 			testRunner, makeDefaultLinkerFlags(path.Base(sr.ModulePath), sr))


### PR DESCRIPTION
This fixes the warning that ginkgo displays when the projects version and globally installed version doesn't match:

```
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.23.4
  Mismatched package versions found:
    2.22.0 used by controller

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
```