### PR TITLE
Provide `BININFO_*` docker build arguments to ghcr container workflow

### DIFF
--- a/internal/ghworkflow/workflow_ghcr.go
+++ b/internal/ghworkflow/workflow_ghcr.go
@@ -97,6 +97,15 @@ type=sha,format=long
 		},
 	})
 	j.addStep(jobStep{
+		Name: "Extract build-args for Docker",
+		ID:   "build_args",
+		Run: makeMultilineYAMLString([]string{
+			`echo "version=$(git describe --tags --always --abbrev=7)" >> $GITHUB_OUTPUT`,
+			`echo "commit=$(git rev-parse --verify HEAD)" >> $GITHUB_OUTPUT`,
+			`echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT`,
+		}),
+	})
+	j.addStep(jobStep{
 		Name: "Set up QEMU",
 		Uses: core.DockerQemuAction,
 	})
@@ -118,6 +127,11 @@ type=sha,format=long
 			"tags":      "${{ steps.meta.outputs.tags }}",
 			"labels":    "${{ steps.meta.outputs.labels }}",
 			"platforms": platforms,
+			"build-args": makeMultilineYAMLString([]string{
+				"BININFO_VERSION=${{ steps.build_args.outputs.version }}",
+				"BININFO_COMMIT_HASH=${{ steps.build_args.outputs.commit }}",
+				"BININFO_BUILD_DATE=${{ steps.build_args.outputs.date }}",
+			}),
 		},
 	})
 	w.Jobs = map[string]job{"build-and-push-image": j}


### PR DESCRIPTION
The resulting changes make to the pipeline:

```diff
diff --git a/.github/workflows/container-registry-ghcr.yaml b/.github/workflows/container-registry-ghcr.yaml
index 73910f5..1755f62 100644
--- a/.github/workflows/container-registry-ghcr.yaml
+++ b/.github/workflows/container-registry-ghcr.yaml
@@ -44,6 +44,12 @@ jobs:
             type=semver,pattern=v{{major}}
             # https://github.com/docker/metadata-action#typesha
             type=sha,format=long
+      - name: Extract build-args for Docker
+        id: build_args
+        run: |
+          echo "version=$(git describe --tags --always --abbrev=7)" >> $GITHUB_OUTPUT
+          echo "commit=$(git rev-parse --verify HEAD)" >> $GITHUB_OUTPUT
+          echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -51,6 +57,10 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
+          build-args: |
+            BININFO_VERSION=${{ steps.build_args.outputs.version }}
+            BININFO_COMMIT_HASH=${{ steps.build_args.outputs.commit }}
+            BININFO_BUILD_DATE=${{ steps.build_args.outputs.date }}
           context: .
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64

```