### PR TITLE
golangci-lint: add dupword ignores for SQL constants

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -71,6 +71,10 @@ linters:
     - usetesting
     - whitespace
   settings:
+    dupword:
+      # Do not choke on SQL statements like `INSERT INTO things (foo, bar, baz) VALUES (TRUE, TRUE, TRUE)`.
+      # And yes, dupword considers the comma to be part of the word, because... I don't know.
+      ignore: [ "TRUE", "TRUE,", "FALSE", "FALSE,", "NULL", "NULL," ]
     errcheck:
       check-type-assertions: false
       # Report about assignment of errors to blank identifier.

--- a/internal/golangcilint/golangci.yaml.tmpl
+++ b/internal/golangcilint/golangci.yaml.tmpl
@@ -71,6 +71,10 @@ linters:
     - usetesting
     - whitespace
   settings:
+    dupword:
+      # Do not choke on SQL statements like `INSERT INTO things (foo, bar, baz) VALUES (TRUE, TRUE, TRUE)`.
+      # And yes, dupword considers the comma to be part of the word, because... I don't know.
+      ignore: [ "TRUE", "TRUE,", "FALSE", "FALSE,", "NULL", "NULL," ]
     errcheck:
       check-type-assertions: false
       # Report about assignment of errors to blank identifier.


### PR DESCRIPTION
This appears to be working now with the most recent dupword version.