### PR TITLE
go-makefile-maker: simplify dupword ignores

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -73,8 +73,7 @@ linters:
   settings:
     dupword:
       # Do not choke on SQL statements like `INSERT INTO things (foo, bar, baz) VALUES (TRUE, TRUE, TRUE)`.
-      # And yes, dupword considers the comma to be part of the word, because... I don't know.
-      ignore: [ "TRUE", "TRUE,", "FALSE", "FALSE,", "NULL", "NULL," ]
+      ignore: [ "TRUE", "FALSE", "NULL" ]
     errcheck:
       check-type-assertions: false
       # Report about assignment of errors to blank identifier.

--- a/internal/golangcilint/golangci.yaml.tmpl
+++ b/internal/golangcilint/golangci.yaml.tmpl
@@ -73,8 +73,7 @@ linters:
   settings:
     dupword:
       # Do not choke on SQL statements like `INSERT INTO things (foo, bar, baz) VALUES (TRUE, TRUE, TRUE)`.
-      # And yes, dupword considers the comma to be part of the word, because... I don't know.
-      ignore: [ "TRUE", "TRUE,", "FALSE", "FALSE,", "NULL", "NULL," ]
+      ignore: [ "TRUE", "FALSE", "NULL" ]
     errcheck:
       check-type-assertions: false
       # Report about assignment of errors to blank identifier.


### PR DESCRIPTION
I got confused because the error message from dupword still says `Duplicate words (TRUE,) found`, suggesting that "TRUE," is what needs to be ignored instead of "TRUE".