### PR TITLE
Only use `ginkgo` test runner if `ginkgo` is a direct dependency

### DIFF
--- a/internal/golang/scan.go
+++ b/internal/golang/scan.go
@@ -64,7 +64,7 @@ func Scan() ScanResult {
 		if v.Mod.Path == "github.com/lib/pq" {
 			usesPostgres = true
 		}
-		if strings.HasPrefix(v.Mod.Path, "github.com/onsi/ginkgo") {
+		if !v.Indirect && strings.HasPrefix(v.Mod.Path, "github.com/onsi/ginkgo") {
 			useGinkgo = true
 		}
 		if v.Mod.Path == "k8s.io/api" {


### PR DESCRIPTION
Only use `ginkgo` test runner if `ginkgo` is a direct dependency, as otherwise the package might be not available.

```
cannot find module providing package github.com/onsi/ginkgo/v2/ginkgo: import lookup disabled by -mod=vendor
	(Go version in go.mod is at least 1.14 and vendor directory exists.)
```

A real example is when `golang.enableVendoring == true`, and [`gomega`](https://github.com/onsi/gomega) is added as a direct dependency but [without direct `ginkgo`](https://onsi.github.io/gomega/#using-gomega-with-golangs-xunit-style-tests), which in turn brings `ginkgo` indirectly - causing the corresponding test target to fail with the error above.