### PR TITLE
bump actions/checkout to v5

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/internal/core/constants.go
+++ b/internal/core/constants.go
@@ -17,7 +17,7 @@ var DefaultGitHubEnterpriseRunsOn = map[string]string{
 var SugarRunsOn = []string{"self-hosted"}
 
 const (
-	CheckoutAction = "actions/checkout@v4"
+	CheckoutAction = "actions/checkout@v5"
 	SetupGoAction  = "actions/setup-go@v5"
 
 	DockerLoginAction     = "docker/login-action@v3"


### PR DESCRIPTION
The changelog looks boring: https://github.com/actions/checkout/releases/tag/v5.0.0