### PR TITLE
Do not try to delete shellcheck on selfhosted runners

### DIFF
--- a/internal/ghworkflow/workflow_checks.go
+++ b/internal/ghworkflow/workflow_checks.go
@@ -29,10 +29,12 @@ func checksWorkflow(cfg core.Configuration) {
 
 	if cfg.ShellCheck.Enabled.UnwrapOr(true) {
 		// delete the pretty out of date installed version of shellcheck so that make install-shellcheck installs the current version
-		j.addStep(jobStep{
-			Name: "Delete pre-installed shellcheck",
-			Run:  "sudo rm -f $(which shellcheck)",
-		})
+		if !ghwCfg.IsSelfHostedRunner {
+			j.addStep(jobStep{
+				Name: "Delete pre-installed shellcheck",
+				Run:  "sudo rm -f $(which shellcheck)",
+			})
+		}
 		j.addStep(jobStep{
 			Name: "Run shellcheck",
 			Run:  "make run-shellcheck",


### PR DESCRIPTION
It is not installed there per default and also on SUGAR runners there is no sudo available. So much about self hosted runners being compatible.