### PR TITLE
scan.go: add usesPostgres detection of github.com/jackc/pgx/v5

### DIFF
--- a/internal/golang/scan.go
+++ b/internal/golang/scan.go
@@ -5,6 +5,7 @@ package golang
 
 import (
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/sapcc/go-bits/must"
@@ -61,7 +62,7 @@ func Scan() ScanResult {
 				hasBinInfo = true
 			}
 		}
-		if v.Mod.Path == "github.com/lib/pq" {
+		if slices.Contains([]string{"github.com/lib/pq", "github.com/jackc/pgx/v5"}, v.Mod.Path) {
 			usesPostgres = true
 		}
 		if !v.Indirect && strings.HasPrefix(v.Mod.Path, "github.com/onsi/ginkgo") {


### PR DESCRIPTION
Archer uses PGX to access PostgreSQL native functions like LISTEN/NOTIFY, and also needs a database for running it's tests.
