### PR TITLE
renovate: fix pinning of Go minor version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,6 +23,7 @@
   "packageRules": [
     {
       "matchPackageNames": [
+        "go",
         "golang"
       ],
       "allowedVersions": "1.24.x"

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ packageRules:
     allowedVersions: 0.28.x
 
   # Restrict updates for versions managed by go-makefile-maker.
-  - matchPackageNames: [ golang ]
+  - matchPackageNames: [ go, golang ]
     allowedVersions: $goVersion.x # only update within the same minor release
   - matchDepTypes: [ action ]
     enabled: false # see githubWorkflow config section below

--- a/internal/renovate/renovate.go
+++ b/internal/renovate/renovate.go
@@ -90,7 +90,7 @@ func RenderConfig(cfgRenovate core.RenovateConfig, scanResult golang.ScanResult,
 		// NOTE: When changing this list, please also adjust the documentation for
 		// default package rules in the README.
 		cfg.PackageRules = append(cfg.PackageRules, core.PackageRule{
-			MatchPackageNames: []string{"golang"},
+			MatchPackageNames: []string{"go", "golang"},
 			AllowedVersions:   cfgRenovate.GoVersion + ".x",
 		})
 


### PR DESCRIPTION
Evidently Renovate changed the package name for the Go toolchain from "golang" to "go". For maximum compatibility, this retains the old name, but also adds the new name.