### PR TITLE
bring back Coveralls as a supported option

### DIFF
--- a/internal/ghworkflow/workflow_ci.go
+++ b/internal/ghworkflow/workflow_ci.go
@@ -53,37 +53,71 @@ func ciWorkflow(cfg core.Configuration, sr golang.ScanResult) {
 		Run:  makeMultilineYAMLString(testCmd),
 	})
 
-	// see https://github.com/fgrosse/go-coverage-report#usage
-	coverageArtifactName := "code-coverage"
-	testJob.addStep(jobStep{
-		Name: "Archive code coverage results",
-		Uses: core.GetUploadArtifactAction(ghwCfg.IsSelfHostedRunner),
-		With: map[string]any{
-			"name": coverageArtifactName,
-			"path": "build/cover.out",
-		},
-	})
+	const coverageArtifactName = "code-coverage"
+	if !ghwCfg.CI.Coveralls {
+		// see https://github.com/fgrosse/go-coverage-report#usage
+		testJob.addStep(jobStep{
+			Name: "Archive code coverage results",
+			Uses: core.GetUploadArtifactAction(ghwCfg.IsSelfHostedRunner),
+			With: map[string]any{
+				"name": coverageArtifactName,
+				"path": "build/cover.out",
+			},
+		})
+	}
 
 	w.Jobs["test"] = testJob
 
-	// see https://github.com/fgrosse/go-coverage-report#usage
-	codeCov := baseJob("Code coverage report", cfg.GitHubWorkflow)
-	codeCov.If = "github.event_name == 'pull_request'"
-	codeCov.Needs = []string{"test"}
-	codeCov.Permissions = permissions{
-		Contents:     "read",
-		Actions:      "read",
-		PullRequests: "write",
+	if ghwCfg.CI.Coveralls {
+		multipleOS := len(ghwCfg.CI.RunsOn) > 1
+		env := map[string]string{
+			"GIT_BRANCH":      "${{ github.head_ref }}",
+			"COVERALLS_TOKEN": "${{ secrets.GITHUB_TOKEN }}",
+		}
+		installGoveralls := "go install github.com/mattn/goveralls@latest"
+		cmd := "goveralls -service=github -coverprofile=build/cover.out"
+		if multipleOS {
+			cmd += ` -parallel -flagname="Unit-${{ matrix.os }}"`
+		}
+		testJob.addStep(jobStep{
+			Name: "Upload coverage report to Coveralls",
+			Run:  makeMultilineYAMLString([]string{installGoveralls, cmd}),
+			Env:  env,
+		})
+
+		if multipleOS {
+			// 04. Tell Coveralls to merge coverage results.
+			finishJob := baseJobWithGo("Finish", cfg)
+			finishJob.Needs = []string{"test"} // this is the <job_id> for the test job
+			finishJob.addStep(jobStep{
+				Name: "Coveralls post build webhook",
+				Run:  makeMultilineYAMLString([]string{installGoveralls, "goveralls -parallel-finish"}),
+				Env:  env,
+			})
+			w.Jobs["finish"] = finishJob
+		}
+	} else {
+		// see https://github.com/fgrosse/go-coverage-report#usage
+		codeCov := baseJob("Code coverage report", cfg.GitHubWorkflow)
+		codeCov.If = "github.event_name == 'pull_request'"
+		codeCov.Needs = []string{"test"}
+		codeCov.Permissions = permissions{
+			Contents:     "read",
+			Actions:      "read",
+			PullRequests: "write",
+		}
+		codeCov.addStep(jobStep{
+			Name: "Post coverage report",
+			Uses: core.GoCoverageReportAction,
+			With: map[string]any{
+				"coverage-artifact-name": coverageArtifactName,
+				"coverage-file-name":     "cover.out",
+			},
+		})
+		w.Jobs["code_coverage"] = codeCov
 	}
-	codeCov.addStep(jobStep{
-		Name: "Post coverage report",
-		Uses: core.GoCoverageReportAction,
-		With: map[string]any{
-			"coverage-artifact-name": coverageArtifactName,
-			"coverage-file-name":     "cover.out",
-		},
-	})
-	w.Jobs["code_coverage"] = codeCov
+
+	w.Jobs["test"] = testJob
 
 	writeWorkflowToFile(w)
 }

--- a/main.go
+++ b/main.go
@@ -112,8 +112,8 @@ func main() {
 	// Render GitHub workflows
 	if cfg.GitHubWorkflow != nil {
 		logg.Debug("rendering GitHub Actions workflows")
-		if cfg.GitHubWorkflow.CI.Coveralls {
-			logg.Fatal("Coveralls support has been removed, please remove it from your Makefile.maker.yaml")
+		if cfg.GitHubWorkflow.CI.Coveralls && cfg.GitHubWorkflow.IsSelfHostedRunner {
+			logg.Fatal("Coveralls is not supported on GitHub Enterprise: please remove `githubWorkflow.ci.coveralls = true` to use the alternative code coverage action")
 		}
 		ghworkflow.Render(cfg, sr)
 	}


### PR DESCRIPTION
The new code coverage option will be used unless Coveralls is explicitly enabled through the preexisting option (which now becomes allowed once more).

My motivation is that I'm not satisfied with the data reported by the new action; see <https://github.com/sapcc/limes/pull/771> for a particularly egregious example. Until these problems are resolved, Coveralls seems like a decent fallback option: It may have availability issues, but at least it has never reported wildly incorrect numbers.