### PR TITLE
Do not generate extra sboms for archives

### DIFF
--- a/internal/goreleaser/goreleaser.yaml.tmpl
+++ b/internal/goreleaser/goreleaser.yaml.tmpl
@@ -58,8 +58,6 @@ release:
   prerelease: auto
 
 sboms:
-  - id: archive
-    artifacts: archive
   - id: binary
     artifacts: binary
   - id: package


### PR DESCRIPTION
```
 ➜ goreleaser release --skip=publish,validate --clean
  • skipping announce, publish, and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=c74df2a997d2ef8cf052f6b6052dcb9f78248abf branch=master current_tag=v2.9.0 previous_tag=v2.8.0 dirty=true
    • pipe skipped or partially skipped              reason=validation is disabled
  • parsing tag
  • setting defaults
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/ntp_exporter_windows_amd64_v1/ntp_exporter.exe
    • building                                       binary=dist/ntp_exporter_darwin_arm64_v8.0/ntp_exporter
    • building                                       binary=dist/ntp_exporter_linux_amd64_v1/ntp_exporter
    • building                                       binary=dist/ntp_exporter_darwin_amd64_v1/ntp_exporter
    • building                                       binary=dist/ntp_exporter_linux_arm64_v8.0/ntp_exporter
      • took: 29s
  • generating changelog
  • archives
    • archiving                                      name=dist/ntp_exporter-2.9.0-darwin-arm64.tar.gz
    • archiving                                      name=dist/ntp_exporter-2.9.0-windows-amd64.zip
    • archiving                                      name=dist/ntp_exporter-2.9.0-darwin-amd64.tar.gz
    • archiving                                      name=dist/ntp_exporter-2.9.0-linux-amd64.tar.gz
    • archiving                                      name=dist/ntp_exporter-2.9.0-linux-arm64.tar.gz
  • cataloging artifacts
    • no artifacts matching current filters
    • cataloging                                     cmd=syft artifact=dist/ntp_exporter_linux_amd64_v1/ntp_exporter sbom=[ntp_exporter_2.9.0_linux_amd64.sbom.json]
    • cataloging                                     cmd=syft artifact=dist/ntp_exporter_linux_arm64_v8.0/ntp_exporter sbom=[ntp_exporter_2.9.0_linux_arm64.sbom.json]
    • cataloging                                     cmd=syft artifact=dist/ntp_exporter_windows_amd64_v1/ntp_exporter.exe sbom=[ntp_exporter_2.9.0_windows_amd64.sbom.json]
    • cataloging                                     cmd=syft artifact=dist/ntp_exporter_darwin_amd64_v1/ntp_exporter sbom=[ntp_exporter_2.9.0_darwin_amd64.sbom.json]
    • cataloging                                     cmd=syft artifact=dist/ntp_exporter_darwin_arm64_v8.0/ntp_exporter sbom=[ntp_exporter_2.9.0_darwin_arm64.sbom.json]
  • calculating checksums
  • writing artifacts metadata
  • release succeeded after 37s
  • thanks for using GoReleaser!

 ➜ ls dist/
 artifacts.json   ntp_exporter-2.9.0-darwin-amd64.tar.gz   ntp_exporter_2.9.0_darwin_amd64.sbom.json    ntp_exporter_darwin_amd64_v1
 CHANGELOG.md     ntp_exporter-2.9.0-darwin-arm64.tar.gz   ntp_exporter_2.9.0_darwin_arm64.sbom.json    ntp_exporter_darwin_arm64_v8.0
 checksums.txt    ntp_exporter-2.9.0-linux-amd64.tar.gz    ntp_exporter_2.9.0_linux_amd64.sbom.json     ntp_exporter_linux_amd64_v1
 config.yaml      ntp_exporter-2.9.0-linux-arm64.tar.gz    ntp_exporter_2.9.0_linux_arm64.sbom.json     ntp_exporter_linux_arm64_v8.0
 metadata.json    ntp_exporter-2.9.0-windows-amd64.zip     ntp_exporter_2.9.0_windows_amd64.sbom.json   ntp_exporter_windows_amd64_v1
```