### PR TITLE
fix the variable override mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,13 @@ install-reuse: FORCE
 
 prepare-static-check: FORCE install-golangci-lint install-modernize install-shellcheck install-go-licence-detector install-addlicense install-reuse
 
-GO_BUILDFLAGS := -mod vendor $(GO_BUILDFLAGS)
-GO_LDFLAGS := $(GO_LDFLAGS)
-GO_TESTFLAGS := $(GO_TESTFLAGS)
-GO_TESTENV := $(GO_TESTENV)
-GO_BUILDENV := $(GO_BUILDENV)
+# To add additional flags or values, specify the variable in the environment, e.g. `GO_BUILDFLAGS='-tags experimental' make`.
+# To override the default flags or values, specify the variable on the command line, e.g. `make GO_BUILDFLAGS='-tags experimental'`.
+GO_BUILDFLAGS += -mod vendor
+GO_LDFLAGS +=
+GO_TESTFLAGS +=
+GO_TESTENV +=
+GO_BUILDENV +=
 
 # These definitions are overridable, e.g. to provide fixed version/commit values when
 # no .git directory is present or to provide a fixed build date for reproducibility.

--- a/internal/makefile/makefile.go
+++ b/internal/makefile/makefile.go
@@ -211,11 +211,13 @@ endif
 	}
 
 	if isGolang {
-		build.addDefinition("GO_BUILDFLAGS :=%s $(GO_BUILDFLAGS)", cfg.Variable("GO_BUILDFLAGS", defaultBuildFlags))
-		build.addDefinition("GO_LDFLAGS :=%s $(GO_LDFLAGS)", cfg.Variable("GO_LDFLAGS", strings.TrimSpace(defaultLdFlags)))
-		build.addDefinition("GO_TESTFLAGS :=%s $(GO_TESTFLAGS)", cfg.Variable("GO_TESTFLAGS", ""))
-		build.addDefinition("GO_TESTENV :=%s $(GO_TESTENV)", cfg.Variable("GO_TESTENV", ""))
-		build.addDefinition("GO_BUILDENV :=%s $(GO_BUILDENV)", cfg.Variable("GO_BUILDENV", ""))
+		build.addDefinition("# To add additional flags or values, specify the variable in the environment, e.g. `GO_BUILDFLAGS='-tags experimental' make`.")
+		build.addDefinition("# To override the default flags or values, specify the variable on the command line, e.g. `make GO_BUILDFLAGS='-tags experimental'`.")
+		build.addDefinition("GO_BUILDFLAGS +=%s", cfg.Variable("GO_BUILDFLAGS", defaultBuildFlags))
+		build.addDefinition("GO_LDFLAGS +=%s", cfg.Variable("GO_LDFLAGS", strings.TrimSpace(defaultLdFlags)))
+		build.addDefinition("GO_TESTFLAGS +=%s", cfg.Variable("GO_TESTFLAGS", ""))
+		build.addDefinition("GO_TESTENV +=%s", cfg.Variable("GO_TESTENV", ""))
+		build.addDefinition("GO_BUILDENV +=%s", cfg.Variable("GO_BUILDENV", ""))
 	}
 	if sr.HasBinInfo {
 		build.addDefinition("")


### PR DESCRIPTION
The override mechanism proposed by @stanislav-zaprudskiy in #352 is problematic because --warn-undefined-variables makes noise about it:

```shellSession
$ make
Makefile:67: warning: undefined variable 'GO_BUILDFLAGS'
Makefile:68: warning: undefined variable 'GO_LDFLAGS'
Makefile:69: warning: undefined variable 'GO_TESTFLAGS'
Makefile:70: warning: undefined variable 'GO_TESTENV'
Makefile:71: warning: undefined variable 'GO_BUILDENV'
env  go build -mod vendor  -ldflags '-s -w ...
```

However, through much experimentation, I discovered that the += operator behaves in the intended way, as documented in the new generated comment.