### PR TITLE
Update variables override mechanism to append

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,11 @@ prepare-static-check: FORCE install-golangci-lint install-modernize install-shel
 
 # To add additional flags or values, specify the variable in the environment, e.g. `GO_BUILDFLAGS='-tags experimental' make`.
 # To override the default flags or values, specify the variable on the command line, e.g. `make GO_BUILDFLAGS='-tags experimental'`.
-GO_BUILDFLAGS += -mod vendor
-GO_LDFLAGS +=
-GO_TESTFLAGS +=
-GO_TESTENV +=
-GO_BUILDENV +=
+GO_BUILDFLAGS := -mod vendor $(GO_BUILDFLAGS)
+GO_LDFLAGS := $(GO_LDFLAGS)
+GO_TESTFLAGS := $(GO_TESTFLAGS)
+GO_TESTENV := $(GO_TESTENV)
+GO_BUILDENV := $(GO_BUILDENV)
 
 # These definitions are overridable, e.g. to provide fixed version/commit values when
 # no .git directory is present or to provide a fixed build date for reproducibility.

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company
 # SPDX-License-Identifier: Apache-2.0
 
-MAKEFLAGS=--warn-undefined-variables
 # /bin/sh is dash on Debian which does not support all features of ash/bash
 # to fix that we use /bin/bash only on Debian to not break Alpine
 ifneq (,$(wildcard /etc/os-release)) # check file existence

--- a/internal/makefile/makefile.go
+++ b/internal/makefile/makefile.go
@@ -213,11 +213,11 @@ endif
 	if isGolang {
 		build.addDefinition("# To add additional flags or values, specify the variable in the environment, e.g. `GO_BUILDFLAGS='-tags experimental' make`.")
 		build.addDefinition("# To override the default flags or values, specify the variable on the command line, e.g. `make GO_BUILDFLAGS='-tags experimental'`.")
-		build.addDefinition("GO_BUILDFLAGS +=%s", cfg.Variable("GO_BUILDFLAGS", defaultBuildFlags))
-		build.addDefinition("GO_LDFLAGS +=%s", cfg.Variable("GO_LDFLAGS", strings.TrimSpace(defaultLdFlags)))
-		build.addDefinition("GO_TESTFLAGS +=%s", cfg.Variable("GO_TESTFLAGS", ""))
-		build.addDefinition("GO_TESTENV +=%s", cfg.Variable("GO_TESTENV", ""))
-		build.addDefinition("GO_BUILDENV +=%s", cfg.Variable("GO_BUILDENV", ""))
+		build.addDefinition("GO_BUILDFLAGS :=%s $(GO_BUILDFLAGS)", cfg.Variable("GO_BUILDFLAGS", defaultBuildFlags))
+		build.addDefinition("GO_LDFLAGS :=%s $(GO_LDFLAGS)", cfg.Variable("GO_LDFLAGS", strings.TrimSpace(defaultLdFlags)))
+		build.addDefinition("GO_TESTFLAGS :=%s $(GO_TESTFLAGS)", cfg.Variable("GO_TESTFLAGS", ""))
+		build.addDefinition("GO_TESTENV :=%s $(GO_TESTENV)", cfg.Variable("GO_TESTENV", ""))
+		build.addDefinition("GO_BUILDENV :=%s $(GO_BUILDENV)", cfg.Variable("GO_BUILDENV", ""))
 	}
 	if sr.HasBinInfo {
 		build.addDefinition("")

--- a/internal/makefile/makefile.go
+++ b/internal/makefile/makefile.go
@@ -46,7 +46,6 @@ func newMakefile(cfg core.Configuration, sr golang.ScanResult) *makefile {
 	// General
 	general := category{name: "general"}
 
-	general.addDefinition("MAKEFLAGS=--warn-undefined-variables")
 	general.addDefinition(strings.TrimSpace(`
 # /bin/sh is dash on Debian which does not support all features of ash/bash
 # to fix that we use /bin/bash only on Debian to not break Alpine


### PR DESCRIPTION
The updated mechanism brought by #362 behaves differently to the behavior in #352 in a way that it _prepends_ to the variable _not appends_ to it when overriding with environment - which makes the overall feature of "adding to a variable" less useful.

The PRs reverts #362 and configures `Makefile` to not produce warnings on unused variables by default:

- **Remove MAKEFLAGS=--warn-undefined-variables**
   This is not generally required, and could manually be added as command
   line argumen when needed e.g. to debug a Makefile.

   > `--warn-undefined-variables'
   >
   > Issue a warning message whenever make sees a reference to an undefined
   > variable. This can be helpful when you are trying to debug makefiles
   > which use variables in complex ways.

---

A practical example. The following configuration works perfectly fine both in regular CI workflow and on local machine:

```yaml
variables:
  GO_TESTFLAGS: "-short -count=1 -v -failfast"
```

but making it execute with `-short=false` (e.g. in a nightly CI workflow) requires providing all other arguments as well, as `+=` prepends to a variable, not appends to it as seen below.

---

Given the following `Makefile`:

```makefile
GO_TESTFLAGS += -short=true

foo:
	@echo flags are \"$(GO_TESTFLAGS)\"
```

it produces:

```console
❯ GO_TESTFLAGS="-short=false" make
flags are "-short=false -short=true"
```

Whereas a `Makefile` updated to

```makefile
GO_TESTFLAGS := -short=true $(GO_TESTFLAGS)
...
```

produces:

```console
❯ GO_TESTFLAGS="-short=false" make
flags are "-short=true -short=false"
```

which would result to an overridden argument when used with e.g. `go test`.