### PR TITLE
Do not set -p 1 in go test unless postgres is being used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ run-shellcheck: FORCE install-shellcheck
 
 build/cover.out: FORCE | build
 	@printf "\e[1;36m>> Running tests\e[0m\n"
-	@env $(GO_TESTENV) go test -shuffle=on -p 1 -coverprofile=build/coverprofile.out $(GO_BUILDFLAGS) -ldflags '-s -w -X github.com/sapcc/go-api-declarations/bininfo.binName=go-makefile-maker -X github.com/sapcc/go-api-declarations/bininfo.version=$(BININFO_VERSION) -X github.com/sapcc/go-api-declarations/bininfo.commit=$(BININFO_COMMIT_HASH) -X github.com/sapcc/go-api-declarations/bininfo.buildDate=$(BININFO_BUILD_DATE) $(GO_LDFLAGS)' -covermode=count -coverpkg=$(subst $(space),$(comma),$(GO_COVERPKGS)) $(GO_TESTFLAGS) $(GO_TESTPKGS)
+	@env $(GO_TESTENV) go test -shuffle=on -coverprofile=build/coverprofile.out $(GO_BUILDFLAGS) -ldflags '-s -w -X github.com/sapcc/go-api-declarations/bininfo.binName=go-makefile-maker -X github.com/sapcc/go-api-declarations/bininfo.version=$(BININFO_VERSION) -X github.com/sapcc/go-api-declarations/bininfo.commit=$(BININFO_COMMIT_HASH) -X github.com/sapcc/go-api-declarations/bininfo.buildDate=$(BININFO_BUILD_DATE) $(GO_LDFLAGS)' -covermode=count -coverpkg=$(subst $(space),$(comma),$(GO_COVERPKGS)) $(GO_TESTFLAGS) $(GO_TESTPKGS)
 	@awk < build/coverprofile.out '$$1 != "mode:" { is_filename[$$1] = true; counts1[$$1]+=$$2; counts2[$$1]+=$$3 } END { for (filename in is_filename) { printf "%s %d %d\n", filename, counts1[filename], counts2[filename]; } }' | sort | $(SED) '1s/^/mode: count\n/' > $@
 
 build/cover.html: build/cover.out


### PR DESCRIPTION
Having `-p 1` in `go test` command is not always desarable. Overriding it to a default value that `go test` uses is tricky:

> -p n
>   the number of programs, such as build commands or
>   test binaries, that can be run in parallel.
>   The default is GOMAXPROCS, normally the number of CPUs available.

especially when executing the respective `make` targets (e.g. `make build/cover.out`) in externally controlled environments such as CI - for example, inside the [ci.yaml workflow](https://github.com/sapcc/go-makefile-maker/blob/bbc2886b85e489d6534be52a73304f95463eb762/internal/ghworkflow/workflow_ci.go#L42) provided by `go-makefile-maker`.

NOTE: this is non-backward compatible change.

One possible remediation for the affected users would be to re-add the removed argument using `GO_TESTFLAGS`.
