### PR TITLE
revert recent changes to variable assignments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company
 # SPDX-License-Identifier: Apache-2.0
 
+MAKEFLAGS=--warn-undefined-variables
 # /bin/sh is dash on Debian which does not support all features of ash/bash
 # to fix that we use /bin/bash only on Debian to not break Alpine
 ifneq (,$(wildcard /etc/os-release)) # check file existence
@@ -51,11 +52,11 @@ prepare-static-check: FORCE install-golangci-lint install-modernize install-shel
 
 # To add additional flags or values, specify the variable in the environment, e.g. `GO_BUILDFLAGS='-tags experimental' make`.
 # To override the default flags or values, specify the variable on the command line, e.g. `make GO_BUILDFLAGS='-tags experimental'`.
-GO_BUILDFLAGS := -mod vendor $(GO_BUILDFLAGS)
-GO_LDFLAGS := $(GO_LDFLAGS)
-GO_TESTFLAGS := $(GO_TESTFLAGS)
-GO_TESTENV := $(GO_TESTENV)
-GO_BUILDENV := $(GO_BUILDENV)
+GO_BUILDFLAGS += -mod vendor
+GO_LDFLAGS +=
+GO_TESTFLAGS +=
+GO_TESTENV +=
+GO_BUILDENV +=
 
 # These definitions are overridable, e.g. to provide fixed version/commit values when
 # no .git directory is present or to provide a fixed build date for reproducibility.

--- a/internal/makefile/makefile.go
+++ b/internal/makefile/makefile.go
@@ -46,6 +46,8 @@ func newMakefile(cfg core.Configuration, sr golang.ScanResult) *makefile {
 	// General
 	general := category{name: "general"}
 
+	// WARNING: Do not remove this just because it may be inconvenient to you. Learn to work with it.
+	general.addDefinition("MAKEFLAGS=--warn-undefined-variables")
 	general.addDefinition(strings.TrimSpace(`
 # /bin/sh is dash on Debian which does not support all features of ash/bash
 # to fix that we use /bin/bash only on Debian to not break Alpine
@@ -210,13 +212,15 @@ endif
 	}
 
 	if isGolang {
+		// WARNING: DO NOT CHANGE THIS WITHOUT FIRST UNDERSTANDING THE CONSEQUENCES.
+		// All changes have to be okay'd by Stefan Majewsky to avoid breaking setups.
 		build.addDefinition("# To add additional flags or values, specify the variable in the environment, e.g. `GO_BUILDFLAGS='-tags experimental' make`.")
 		build.addDefinition("# To override the default flags or values, specify the variable on the command line, e.g. `make GO_BUILDFLAGS='-tags experimental'`.")
-		build.addDefinition("GO_BUILDFLAGS :=%s $(GO_BUILDFLAGS)", cfg.Variable("GO_BUILDFLAGS", defaultBuildFlags))
-		build.addDefinition("GO_LDFLAGS :=%s $(GO_LDFLAGS)", cfg.Variable("GO_LDFLAGS", strings.TrimSpace(defaultLdFlags)))
-		build.addDefinition("GO_TESTFLAGS :=%s $(GO_TESTFLAGS)", cfg.Variable("GO_TESTFLAGS", ""))
-		build.addDefinition("GO_TESTENV :=%s $(GO_TESTENV)", cfg.Variable("GO_TESTENV", ""))
-		build.addDefinition("GO_BUILDENV :=%s $(GO_BUILDENV)", cfg.Variable("GO_BUILDENV", ""))
+		build.addDefinition("GO_BUILDFLAGS +=%s", cfg.Variable("GO_BUILDFLAGS", defaultBuildFlags))
+		build.addDefinition("GO_LDFLAGS +=%s", cfg.Variable("GO_LDFLAGS", strings.TrimSpace(defaultLdFlags)))
+		build.addDefinition("GO_TESTFLAGS +=%s", cfg.Variable("GO_TESTFLAGS", ""))
+		build.addDefinition("GO_TESTENV +=%s", cfg.Variable("GO_TESTENV", ""))
+		build.addDefinition("GO_BUILDENV +=%s", cfg.Variable("GO_BUILDENV", ""))
 	}
 	if sr.HasBinInfo {
 		build.addDefinition("")


### PR DESCRIPTION
This reverts commit d3da286e49054badc6d3665e5e9d787c21caef53 and 8f69811fe61a8bcc701f25841526761a651c6844.

These commits seem to have been made without understanding how the variable mechanism is supposed to work. They also invalidate the documentation that's right next to the changed lines.