### PR TITLE
require security scan tools on SAP projects

### DIFF
--- a/internal/makefile/makefile.go
+++ b/internal/makefile/makefile.go
@@ -35,12 +35,7 @@ func newMakefile(cfg core.Configuration, sr golang.ScanResult) *makefile {
 	runControllerGen := cfg.ControllerGen.Enabled.UnwrapOr(sr.KubernetesController)
 	// TODO: checking on GoVersion is only an aid until we can properly detect rust applications
 	isGolang := sr.GoVersion != ""
-	isSAPCC := strings.HasPrefix(cfg.Metadata.URL, "https://github.com/sapcc/") ||
-		strings.HasPrefix(cfg.Metadata.URL, "https://github.com/SAP-cloud-infrastructure/") ||
-		strings.HasPrefix(cfg.Metadata.URL, "https://github.com/cobaltcore-dev/") ||
-		strings.HasPrefix(cfg.Metadata.URL, "https://github.com/ironcore-dev/") ||
-		strings.HasPrefix(cfg.Metadata.URL, "https://github.wdf.sap.corp/") ||
-		strings.HasPrefix(cfg.Metadata.URL, "https://github.tools.sap/")
+	isSAPCC := cfg.Metadata.IsSAPProject()
 
 	///////////////////////////////////////////////////////////////////////////
 	// General


### PR DESCRIPTION
To make it harder to accidentally avoid compliance-relevant features.