### PR TITLE
Add support for controller-gen applyconfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ controllerGen:
   crdOutputPath: config/crd/bases
   objectHeaderFile: boilerplate.go.txt
   rbacRoleName: manager-role
+  applyconfigurationHeaderFile: boilerplate.go.txt
 ```
 
 Customization options for [controller-gen](https://book.kubebuilder.io/reference/controller-gen.html).
@@ -127,6 +128,27 @@ This is only relevant if your project is using controller-gen to autogenerate co
 - `crdOutputPath` allows changing the `output:crd:artifacts:config` argument given to `controller-gen rbac`. Defaults to `crd`.
 - `objectHeaderFile` allows changing the `headerFile` argument given to `controller-gen object`.
 - `rbacRoleName` allows changing the `roleName` argument given to `controller-gen rbac:role-name=`. Defaults to the last element in the go module name.
+- `applyconfigurationHeaderFile` allows changing the `headerFile` argument given to `controller-gen applyconfiguration`.
+
+You need to opt-in object helpers with a comment usually on a package level
+in `groupversion_info.go` like this
+```golang
+// +kubebuilder:object:generate=true
+```
+This is usually already done by kubebuilder and similar tools automatically.
+If you also want to have `Applyconfigurations` you'll need to add a comment like this:
+```golang
+// +kubebuilder:ac:generate=true
+// +kubebuilder:ac:output:package=../../applyconfigurations
+```
+The output is just a suggestion and depends on your directory-layout.
+By default, the generated code will land in `applyconfigurations` subfolder
+of the folder that contains the file with directives in the comments.
+I.e. if you only add the comment `kubebuilder:ac:generate=true` into `api/v1/groupversion_info.go`,
+the generated code will land in `api/v1/applyconfigurations/api/v1`.
+
+As the time of writing, the documentation is limited and you best find
+your way along the [related issue](https://github.com/kubernetes-sigs/controller-runtime/issues/3183) in the controller-runtime.
 
 ### `coverageTest`
 

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -248,10 +248,11 @@ type DockerfileConfig struct {
 }
 
 type ControllerGen struct {
-	Enabled          Option[bool] `yaml:"enabled"`
-	CrdOutputPath    string       `yaml:"crdOutputPath"`
-	ObjectHeaderFile string       `yaml:"objectHeaderFile"`
-	RBACRoleName     string       `yaml:"rbacRoleName"`
+	Enabled                      Option[bool] `yaml:"enabled"`
+	CrdOutputPath                string       `yaml:"crdOutputPath"`
+	ObjectHeaderFile             string       `yaml:"objectHeaderFile"`
+	RBACRoleName                 string       `yaml:"rbacRoleName"`
+	ApplyconfigurationHeaderFile string       `yaml:"applyconfigurationHeaderFile"`
 }
 
 type LicenseConfig struct {

--- a/internal/makefile/makefile.go
+++ b/internal/makefile/makefile.go
@@ -313,6 +313,10 @@ endif
 			if cfg.ControllerGen.ObjectHeaderFile != "" {
 				objectParams = fmt.Sprintf(`:headerFile="%s"`, cfg.ControllerGen.ObjectHeaderFile)
 			}
+			applyconfigurationParams := ""
+			if cfg.ControllerGen.ApplyconfigurationHeaderFile != "" {
+				applyconfigurationParams = fmt.Sprintf(`:headerFile="%s"`, cfg.ControllerGen.ApplyconfigurationHeaderFile)
+			}
 			test.addRule(rule{
 				description: "Generate code for Kubernetes CRDs and deepcopy.",
 				target:      "generate",
@@ -320,6 +324,7 @@ endif
 					`@printf "\e[1;36m>> controller-gen\e[0m\n"`,
 					fmt.Sprintf(`@controller-gen crd rbac:roleName=%s webhook paths="./..." output:crd:artifacts:config=%s`, roleName, crdOutputPath),
 					fmt.Sprintf(`@controller-gen object%s paths="./..."`, objectParams),
+					fmt.Sprintf(`@controller-gen applyconfiguration%s paths="./..."`, applyconfigurationParams),
 				},
 				prerequisites: []string{"install-controller-gen"},
 			})


### PR DESCRIPTION
This is needed for making use of server-side apply in the controller-runtime.

See the umbrella issue for details: kubernetes-sigs/controller-runtime#3183

It requires an opt-in via a comment ,
the same way you opt-in to the deep-copy functions.