### PR TITLE
use "go-version-file" for actions/setup-go

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           check-latest: true
-          go-version: 1.26.0
+          go-version-file: go.mod
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           check-latest: true
-          go-version: 1.26.0
+          go-version-file: go.mod
       - name: Build all binaries
         run: make build-all
   code_coverage:
@@ -65,7 +65,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           check-latest: true
-          go-version: 1.26.0
+          go-version-file: go.mod
       - name: Run tests and generate coverage report
         run: make build/cover.out
       - name: Archive code coverage results

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           check-latest: true
-          go-version: 1.26.0
+          go-version-file: go.mod
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:

--- a/.github/workflows/run-go-makefile-maker.yaml
+++ b/.github/workflows/run-go-makefile-maker.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           check-latest: true
-          go-version: 1.26.0
+          go-version-file: go.mod
 
       - name: Build, run and push
         run: |

--- a/internal/ghworkflow/utils.go
+++ b/internal/ghworkflow/utils.go
@@ -74,8 +74,8 @@ func baseJobWithGo(name string, cfg core.Configuration) job {
 		Name: "Set up Go",
 		Uses: core.SetupGoAction,
 		With: map[string]any{
-			"go-version":   cfg.GitHubWorkflow.Global.GoVersion.UnwrapOr(core.DefaultGoVersion),
-			"check-latest": true,
+			"go-version-file": "go.mod",
+			"check-latest":    true,
 		},
 	})
 	if cfg.GitHubWorkflow.CI.PrepareMakeTarget != "" {


### PR DESCRIPTION
@kayrus pointed out this setting in https://github.com/sapcc/maintenance-controller/pull/369#discussion_r2863639840, and [its specification](https://github.com/actions/setup-go/blob/main/docs/advanced-usage.md#using-the-go-version-file-input) sounds like what we want. This would be a nice way to reduce some noise in the git log because we don't have to change version strings all the time when new Go versions are released.