### PR TITLE
Pass year parameter to controller-gen object for YEAR substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,10 @@ This is only relevant if your project is using controller-gen to autogenerate co
 
 - `enabled` defaults to whether `sigs.k8s.io/controller-runtime` is a library dependency, unless set explicitly.
 - `crdOutputPath` allows changing the `output:crd:artifacts:config` argument given to `controller-gen rbac`. Defaults to `crd`.
-- `objectHeaderFile` allows changing the `headerFile` argument given to `controller-gen object`.
+- `objectHeaderFile` allows changing the `headerFile` argument given to `controller-gen object`. When set, a `year=$(YEAR)` parameter is also passed so that any literal `YEAR` string in the header file is replaced with the current year.
 - `rbacRoleName` allows changing the `roleName` argument given to `controller-gen rbac:role-name=`. Defaults to the last element in the go module name.
 - `rbacOutputPath` allows changing the `output:rbac:artifacts:config` argument given to `controller-gen`. Defaults to `config/rbac`.
-- `applyconfigurationHeaderFile` allows changing the `headerFile` argument given to `controller-gen applyconfiguration`.
+- `applyconfigurationHeaderFile` allows changing the `headerFile` argument given to `controller-gen applyconfiguration`. The `applyconfiguration` generator automatically replaces any literal `YEAR` string in the header file with the current year.
 - Setting `allowDangerousTypes` to true will run `controller-gen` CRD generation with the `allowDangerousTypes=true` flag, allowing the use of float32 and float64 fields.
 
 You need to opt-in object helpers with a comment usually on a package level

--- a/internal/makefile/makefile.go
+++ b/internal/makefile/makefile.go
@@ -352,6 +352,7 @@ endif
 		})
 
 		if runControllerGen {
+			test.addDefinition(`YEAR ?= $(shell date +%Y)`)
 			crdOutputPath := "crd"
 			if cfg.ControllerGen.CrdOutputPath != "" {
 				crdOutputPath = cfg.ControllerGen.CrdOutputPath
@@ -367,7 +368,7 @@ endif
 			}
 			objectParams := ""
 			if cfg.ControllerGen.ObjectHeaderFile != "" {
-				objectParams = fmt.Sprintf(`:headerFile="%s"`, cfg.ControllerGen.ObjectHeaderFile)
+				objectParams = fmt.Sprintf(`:headerFile="%s",year=$(YEAR)`, cfg.ControllerGen.ObjectHeaderFile)
 			}
 			applyconfigurationParams := ""
 			if cfg.ControllerGen.ApplyconfigurationHeaderFile != "" {


### PR DESCRIPTION
Define a YEAR Makefile variable (defaulting to the current year) when controller-gen is enabled, and pass it as year=$(YEAR) to the controller-gen object invocation when a headerFile is configured. This allows boilerplate header files containing the literal string "YEAR" to have it replaced with the actual year. [^1]

The applyconfiguration generator handles this substitution automatically by using kubernetes/gengo and does not need the explicit parameter. [^2]

[^1]: https://github.com/kubernetes-sigs/controller-tools/pull/544
[^2]: https://github.com/kubernetes/gengo/blob/5ee0d033ba5bcb073f0e69c32057520b82d75ccb/v2/execute.go#L59