### PR TITLE
add renovate customManager for GitHub Actions in constants.go

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -60,6 +60,35 @@
       "dependencyDashboardApproval": true
     }
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "datasourceTemplate": "github-releases",
+      "description": "Update GitHub Actions in constants.go (major-only versions)",
+      "extractVersionTemplate": "^v(?<version>\\d+)",
+      "managerFilePatterns": [
+        "internal/core/constants.go"
+      ],
+      "matchStrings": [
+        "\\w+\\s*=\\s*\"(?<depName>[\\w-]+/[\\w-]+)@v(?<currentValue>\\d+)\"",
+        "\\w+\\s*=\\s*\"(?<depName>[\\w-]+/[\\w-]+/[\\w-]+)@v(?<currentValue>\\d+)\""
+      ],
+      "versioningTemplate": "regex:^v?(?<major>\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "datasourceTemplate": "github-releases",
+      "description": "Update GitHub Actions in constants.go (semver versions)",
+      "extractVersionTemplate": "^v(?<version>.*)$",
+      "managerFilePatterns": [
+        "internal/core/constants.go"
+      ],
+      "matchStrings": [
+        "\\w+\\s*=\\s*\"(?<depName>[\\w-]+/[\\w-]+)@v(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
+        "\\w+\\s*=\\s*\"(?<depName>[\\w-]+/[\\w-]+/[\\w-]+)@v(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ]
+    }
+  ],
   "prHourlyLimit": 0,
   "schedule": [
     "before 8am on Friday"

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -36,6 +36,26 @@ renovate:
   enabled: true
   assignees:
     - SuperSandro2000
+  customManagers:
+    - customType: regex
+      description: Update GitHub Actions in constants.go (major-only versions)
+      managerFilePatterns:
+        - internal/core/constants.go
+      matchStrings:
+        - '\w+\s*=\s*"(?<depName>[\w-]+/[\w-]+)@v(?<currentValue>\d+)"'
+        - '\w+\s*=\s*"(?<depName>[\w-]+/[\w-]+/[\w-]+)@v(?<currentValue>\d+)"'
+      datasourceTemplate: github-releases
+      versioningTemplate: "regex:^v?(?<major>\\d+)$"
+      extractVersionTemplate: "^v(?<version>\\d+)"
+    - customType: regex
+      description: Update GitHub Actions in constants.go (semver versions)
+      managerFilePatterns:
+        - internal/core/constants.go
+      matchStrings:
+        - '\w+\s*=\s*"(?<depName>[\w-]+/[\w-]+)@v(?<currentValue>\d+\.\d+\.\d+)"'
+        - '\w+\s*=\s*"(?<depName>[\w-]+/[\w-]+/[\w-]+)@v(?<currentValue>\d+\.\d+\.\d+)"'
+      datasourceTemplate: github-releases
+      extractVersionTemplate: "^v(?<version>.*)$"
 
 reuse:
   annotations:


### PR DESCRIPTION
Automatically update action versions in internal/core/constants.go.
Major-only versions (e.g. @v6) will only update to new majors.
Full semver versions (e.g. @v1.3.0) update normally.

Validation:

Run

```sh
LOG_LEVEL=debug GITHUB_COM_TOKEN=<__GITHUB.COM TOKEN__> renovate --dry-run --platform=local
...
         {
           "branchName": "renovate/azure-setup-helm-5.x",
           "prNo": null,
           "prTitle": "Renovate: Update dependency azure/setup-helm to v5",
           "result": "not-scheduled",
           "upgrades": [
             {
               "datasource": "github-releases",
               "depName": "azure/setup-helm",
               "displayPending": "",
               "fixedVersion": "4",
               "currentVersion": "4",
               "currentValue": "4",
               "newValue": "5",
               "newVersion": "5",
               "packageFile": "internal/core/constants.go",
               "updateType": "major",
               "packageName": "azure/setup-helm"
             }
           ]
         }
```
