### PR TITLE
Fix go-oidc rule

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -94,7 +94,7 @@ linters:
         - pattern: ^http\.Handle(?:Func)?$
         - pkg: ^gopkg\.in/square/go-jose\.v2
           msg: gopk.in/square/go-jose is archived and has CVEs. Replace it with gopkg.in/go-jose/go-jose.v2
-        - pkg: ^github\.com/coreos/go-oidc
+        - pkg: ^github\.com/coreos/go-oidc$
           msg: github.com/coreos/go-oidc depends on gopkg.in/square/go-jose which has CVEs. Replace it with github.com/coreos/go-oidc/v3
         - pkg: ^github\.com/howeyc/gopass
           msg: github.com/howeyc/gopass is archived, use golang.org/x/term instead

--- a/internal/golangcilint/golangci.yaml.tmpl
+++ b/internal/golangcilint/golangci.yaml.tmpl
@@ -102,7 +102,7 @@ linters:
         - pattern: ^http\.Handle(?:Func)?$
         - pkg: ^gopkg\.in/square/go-jose\.v2
           msg: gopk.in/square/go-jose is archived and has CVEs. Replace it with gopkg.in/go-jose/go-jose.v2
-        - pkg: ^github\.com/coreos/go-oidc
+        - pkg: ^github\.com/coreos/go-oidc$
           msg: github.com/coreos/go-oidc depends on gopkg.in/square/go-jose which has CVEs. Replace it with github.com/coreos/go-oidc/v3
         - pkg: ^github\.com/howeyc/gopass
           msg: github.com/howeyc/gopass is archived, use golang.org/x/term instead


### PR DESCRIPTION
It was actually correct as the v2 imports are just bare top level package ones.