### PR TITLE
Remove obsolete typos binary cleanup step

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -44,8 +44,6 @@ jobs:
         uses: crate-ci/typos@v1
         env:
           CLICOLOR: "1"
-      - name: Delete typos binary
-        run: rm typos
       - name: Check if source code files have license header
         run: make check-addlicense
       - name: REUSE Compliance Check

--- a/internal/ghworkflow/workflow_checks.go
+++ b/internal/ghworkflow/workflow_checks.go
@@ -52,12 +52,6 @@ func checksWorkflow(cfg core.Configuration) {
 			"CLICOLOR": "1",
 		},
 	})
-	// TyposAction drops its binary into the repository root; if we do not clean this up,
-	// `reuse lint` will complain about it not having license information
-	j.addStep(jobStep{
-		Name: "Delete typos binary",
-		Run:  "rm typos",
-	})
 
 	if ghwCfg.License.IsEnabled() {
 		j.addStep(jobStep{


### PR DESCRIPTION
TyposAction no longer drops its binary into the repository root,
so this cleanup step is no longer needed.

see https://github.com/crate-ci/typos/releases/tag/v1.45.1
