### PR TITLE
Revert "limit parallelism in goreleaser"

### DIFF
--- a/internal/ghworkflow/workflow_release.go
+++ b/internal/ghworkflow/workflow_release.go
@@ -43,7 +43,7 @@ func releaseWorkflow(cfg core.Configuration) {
 		Uses: core.GoreleaserAction,
 		With: map[string]any{
 			"version": "latest",
-			"args":    "release --clean --release-notes=./build/release-info --parallelism=$(($(nproc)/2))",
+			"args":    "release --clean --release-notes=./build/release-info",
 		},
 		Env: map[string]string{ //nolint:gosec // not a hardcoded secret, we are doing templating here
 			"GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}",


### PR DESCRIPTION
This reverts commit d20c15eb853252c3fa21d5812cd886751dfaddca.
Fixes #493
