### PR TITLE
Add configurable RBAC output path for controller-gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ controllerGen:
   crdOutputPath: config/crd/bases
   objectHeaderFile: boilerplate.go.txt
   rbacRoleName: manager-role
+  rbacOutputPath: config/rbac
   applyconfigurationHeaderFile: boilerplate.go.txt
 ```
 
@@ -140,6 +141,7 @@ This is only relevant if your project is using controller-gen to autogenerate co
 - `crdOutputPath` allows changing the `output:crd:artifacts:config` argument given to `controller-gen rbac`. Defaults to `crd`.
 - `objectHeaderFile` allows changing the `headerFile` argument given to `controller-gen object`.
 - `rbacRoleName` allows changing the `roleName` argument given to `controller-gen rbac:role-name=`. Defaults to the last element in the go module name.
+- `rbacOutputPath` allows changing the `output:rbac:artifacts:config` argument given to `controller-gen`. Defaults to `config/rbac`.
 - `applyconfigurationHeaderFile` allows changing the `headerFile` argument given to `controller-gen applyconfiguration`.
 - Setting `allowDangerousTypes` to true will run `controller-gen` CRD generation with the `allowDangerousTypes=true` flag, allowing the use of float32 and float64 fields.
 

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -318,6 +318,7 @@ type ControllerGen struct {
 	CrdOutputPath                string       `yaml:"crdOutputPath"`
 	ObjectHeaderFile             string       `yaml:"objectHeaderFile"`
 	RBACRoleName                 string       `yaml:"rbacRoleName"`
+	RBACOutputPath               string       `yaml:"rbacOutputPath"`
 	ApplyconfigurationHeaderFile string       `yaml:"applyconfigurationHeaderFile"`
 	AllowDangerousTypes          bool         `yaml:"allowDangerousTypes"`
 }

--- a/internal/makefile/makefile.go
+++ b/internal/makefile/makefile.go
@@ -356,6 +356,10 @@ endif
 			if cfg.ControllerGen.CrdOutputPath != "" {
 				crdOutputPath = cfg.ControllerGen.CrdOutputPath
 			}
+			rbacOutputPath := "config/rbac"
+			if cfg.ControllerGen.RBACOutputPath != "" {
+				rbacOutputPath = cfg.ControllerGen.RBACOutputPath
+			}
 			components := strings.Split(sr.ModulePath, "/")
 			roleName := components[len(components)-1]
 			if cfg.ControllerGen.RBACRoleName != "" {
@@ -378,7 +382,7 @@ endif
 				target:      "generate",
 				recipe: []string{
 					`@printf "\e[1;36m>> controller-gen\e[0m\n"`,
-					fmt.Sprintf(`@controller-gen crd%s rbac:roleName=%s webhook paths="./..." output:crd:artifacts:config=%s`, allowDangerousTypes, roleName, crdOutputPath),
+					fmt.Sprintf(`@controller-gen crd%s rbac:roleName=%s webhook paths="./..." output:crd:artifacts:config=%s output:rbac:artifacts:config=%s`, allowDangerousTypes, roleName, crdOutputPath, rbacOutputPath),
 					fmt.Sprintf(`@controller-gen object%s paths="./..."`, objectParams),
 					fmt.Sprintf(`@controller-gen applyconfiguration%s paths="./..."`, applyconfigurationParams),
 				},


### PR DESCRIPTION
Allow overriding the default "config/rbac" output directory via the rbacOutputPath field in the controllerGen configuration.