### PR TITLE
golangci-lint: set `ignore-tests: true` for goconst linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -102,6 +102,7 @@ linters:
           msg: github.com/containers/image/v5 is deprecated and was replaced with go.podman.io/image/v5
     goconst:
       min-occurrences: 5
+      ignore-tests: true
     gocritic:
       enabled-checks:
         - boolExprSimplify

--- a/internal/golangcilint/golangci.yaml.tmpl
+++ b/internal/golangcilint/golangci.yaml.tmpl
@@ -117,6 +117,7 @@ linters:
 {{- end }}
     goconst:
       min-occurrences: 5
+      ignore-tests: true
     gocritic:
       enabled-checks:
         - boolExprSimplify


### PR DESCRIPTION
As of golangci-lint 2.12.1, goconst is much more sensitive. In go-bits, it finds string literals that are repeated in tests and complains to use a constant instead. But reusing a constant from the implementation in the tests would mean that e.g. typos in the source code are not detected, so this duplication is intentional.