### PR TITLE
Support cross-compilation in generated Dockerfile for faster multi-platform builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ dockerfile:
   extraPackages:
     - curl
     - openssl
+  crossCompile: true
   runAsRoot: true
   useBuildKit: true
   withLinkerdAwait: true
@@ -221,6 +222,7 @@ As an additional smoke test, the compiled binaries are invoked with the `--versi
 With [go-api-declarations](https://github.com/sapcc/go-api-declarations)'s [`bininfo.HandleVersionArgument` function](https://pkg.go.dev/github.com/sapcc/go-api-declarations/bininfo#HandleVersionArgument), this can be implemented in one line. If you are using Cobra or any other library to handle arguments, the [`bininfo.Version` function](https://pkg.go.dev/github.com/sapcc/go-api-declarations/bininfo#Version) is recommended instead.
 
 * `checkEnv` sets environment variables for `make check` inside the docker check build.
+* `crossCompile` enables cross-compilation for multi-platform Docker builds. When enabled, the builder stage runs natively on the build platform and cross-compiles using `GOOS`/`GOARCH`, avoiding slow QEMU emulation. This disables CGO (`CGO_ENABLED=0`), so set this to `false` if your project requires CGO. When unset, cross-compilation is automatically enabled if `pushContainerToGhcr.platforms` contains multiple architectures.
 * `entrypoint` allows overwriting the final entrypoint.
 * `extraBuildStages` prepends additional build stages at the top of the Dockerfile. This is useful for bringing in precompiled assets from other images, or if a non-Go compilation step is required.
 * `extraBuildPackages` installs extra Alpine packages in the Docker layer where `make install` is executed. We always install `ca-certificates`, `gcc`, `git`, `make` and `musl-dev`.

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -298,18 +298,19 @@ type EnvRcConfig struct {
 
 // DockerfileConfig appears in type Configuration.
 type DockerfileConfig struct {
-	Enabled              bool     `yaml:"enabled"`
-	CheckEnv             []string `yaml:"checkEnv"`
-	Entrypoint           []string `yaml:"entrypoint"`
-	ExtraBuildDirectives []string `yaml:"extraBuildDirectives"`
-	ExtraBuildPackages   []string `yaml:"extraBuildPackages"`
-	ExtraBuildStages     []string `yaml:"extraBuildStages"`
-	ExtraDirectives      []string `yaml:"extraDirectives"`
-	ExtraIgnores         []string `yaml:"extraIgnores"`
-	ExtraPackages        []string `yaml:"extraPackages"`
-	RunAsRoot            bool     `yaml:"runAsRoot"`
-	UseBuildKit          bool     `yaml:"useBuildKit"`
-	WithLinkerdAwait     bool     `yaml:"withLinkerdAwait"`
+	Enabled              bool         `yaml:"enabled"`
+	CheckEnv             []string     `yaml:"checkEnv"`
+	CrossCompile         Option[bool] `yaml:"crossCompile"`
+	Entrypoint           []string     `yaml:"entrypoint"`
+	ExtraBuildDirectives []string     `yaml:"extraBuildDirectives"`
+	ExtraBuildPackages   []string     `yaml:"extraBuildPackages"`
+	ExtraBuildStages     []string     `yaml:"extraBuildStages"`
+	ExtraDirectives      []string     `yaml:"extraDirectives"`
+	ExtraIgnores         []string     `yaml:"extraIgnores"`
+	ExtraPackages        []string     `yaml:"extraPackages"`
+	RunAsRoot            bool         `yaml:"runAsRoot"`
+	UseBuildKit          bool         `yaml:"useBuildKit"`
+	WithLinkerdAwait     bool         `yaml:"withLinkerdAwait"`
 }
 
 // ControllerGen appears in type Configuration.

--- a/internal/dockerfile/Dockerfile.tmpl
+++ b/internal/dockerfile/Dockerfile.tmpl
@@ -10,15 +10,18 @@
 
 {{ end -}}
 
-FROM {{ .DockerHubMirror }}golang:{{ .Constants.DefaultGoVersion }}-alpine{{ .Constants.DefaultAlpineImage }} AS builder
+FROM {{ if .CrossCompile }}--platform=$BUILDPLATFORM {{ end }}{{ .DockerHubMirror }}golang:{{ .Constants.DefaultGoVersion }}-alpine{{ .Constants.DefaultAlpineImage }} AS builder
 
-RUN apk add --no-cache --no-progress ca-certificates gcc git make musl-dev {{- range $dcfg.ExtraBuildPackages }} {{.}}{{ end }}
+RUN apk add --no-cache --no-progress ca-certificates{{ if not .CrossCompile }} gcc musl-dev{{ end }} git make {{- range $dcfg.ExtraBuildPackages }} {{.}}{{ end }}
 
 COPY . /src
 ARG BININFO_BUILD_DATE BININFO_COMMIT_HASH BININFO_VERSION # provided to 'make install'
+{{ if .CrossCompile -}}
+ARG TARGETOS TARGETARCH
+{{ end -}}
 RUN {{ if .UseBuildKit }}--mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-  {{ end }}make -C /src install PREFIX=/pkg GOTOOLCHAIN=local{{ if .Config.Golang.EnableVendoring }} GO_BUILDFLAGS='-mod vendor'{{ end }}
+  {{ end }}{{ if .CrossCompile }}CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH {{ end }}make -C /src install PREFIX=/pkg GOTOOLCHAIN=local{{ if .Config.Golang.EnableVendoring }} GO_BUILDFLAGS='-mod vendor'{{ end }}
 
 {{ range $dcfg.ExtraBuildDirectives -}}
 {{ . }}
@@ -67,6 +70,9 @@ FROM {{ .DockerHubMirror }}alpine:{{ .Constants.DefaultAlpineImage }}
 RUN addgroup -g 4200 appgroup \
   && adduser -h /home/appuser -s /sbin/nologin -G appgroup -D -u 4200 appuser
 
+{{ end -}}
+{{ if .WithLinkerdAwait -}}
+ARG TARGETARCH
 {{ end -}}
 # upgrade all installed packages to fix potential CVEs in advance
 # also remove apk package manager to hopefully remove dependency on OpenSSL 🤞

--- a/internal/dockerfile/docker.go
+++ b/internal/dockerfile/docker.go
@@ -44,7 +44,7 @@ func RenderConfig(cfg core.Configuration, sr golang.ScanResult) {
 	if cfg.Dockerfile.WithLinkerdAwait {
 		commands = append(commands,
 			fmt.Sprintf(
-				"wget -qO /usr/bin/linkerd-await https://github.com/linkerd/linkerd-await/releases/download/release%%2Fv%[1]s/linkerd-await-v%[1]s-amd64",
+				"wget -qO /usr/bin/linkerd-await https://github.com/linkerd/linkerd-await/releases/download/release%%2Fv%[1]s/linkerd-await-v%[1]s-$TARGETARCH",
 				core.DefaultLinkerdAwaitVersion,
 			),
 			"chmod 755 /usr/bin/linkerd-await",
@@ -94,6 +94,10 @@ func RenderConfig(cfg core.Configuration, sr golang.ScanResult) {
 		extraTestPackages = append(extraTestPackages, "postgresql")
 	}
 
+	crossCompile := cfg.Dockerfile.CrossCompile.UnwrapOr(
+		cfg.GitHubWorkflow != nil && strings.Contains(cfg.GitHubWorkflow.PushContainerToGhcr.Platforms, ","),
+	)
+
 	must.Succeed(util.WriteFileFromTemplate("Dockerfile", dockerfileTemplate, map[string]any{
 		"Config": cfg,
 		"Constants": map[string]any{
@@ -109,6 +113,8 @@ func RenderConfig(cfg core.Configuration, sr golang.ScanResult) {
 		"RunCommands":        strings.Join(commands, " \\\n  && "),
 		"RunVersionCommands": strings.Join(runVersionCommands, " \\\n  && "),
 		"UseBuildKit":        cfg.Dockerfile.UseBuildKit,
+		"CrossCompile":       crossCompile,
+		"WithLinkerdAwait":   cfg.Dockerfile.WithLinkerdAwait,
 	}))
 
 	ignores := cfg.Dockerfile.ExtraIgnores


### PR DESCRIPTION
When multiple platforms are configured in pushContainerToGhcr.platforms, the generated Dockerfile now uses `--platform=$BUILDPLATFORM` on the builder stage and passes `GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0` to the build command. This avoids slow QEMU emulation by cross-compiling natively.

The behavior can be explicitly controlled via the new crossCompile option in the dockerfile config section (Option[bool]: unset=auto, true/false=override).

Also this PR fixes a bug that happens when `withLinkerdAwait` was enabled: it was hardcoded to amd64 version - now it's downloaded for the target platform.