### PR TITLE
feat(dockerfile): add support for extra packages in test stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ dockerfile:
   extraPackages:
     - curl
     - openssl
+  extraTestPackages:
+    - curl
   runAsRoot: true
   useBuildKit: true
   withLinkerdAwait: true
@@ -228,6 +230,7 @@ With [go-api-declarations](https://github.com/sapcc/go-api-declarations)'s [`bin
 * `extraDirectives` appends additional directives near the end of the Dockerfile.
 * `extraIgnores` appends entries in `.dockerignore` to the default ones.
 * `extraPackages` installs extra Alpine packages in the final Docker layer. `ca-certificates` is always installed.
+* `extraTestPackages` installs extra Alpine packages in the test stage Docker layer.
 * `runAsRoot` skips the privilege drop in the Dockerfile, i.e. the `USER appuser:appgroup` command is not added.
 * `useBuildKit` enables the use of Docker BuildKit for building the image. This is recommended for better performance and caching but requires the feature to be enabled via the `DOCKER_BUILDKIT=1` environment variable or in the Docker daemon config file.
 * `withLinkerdAwait` whether to download the binary and prepend linkerd-await to the entrypoint. For more details see <https://github.com/linkerd/linkerd-await>.

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -307,6 +307,7 @@ type DockerfileConfig struct {
 	ExtraDirectives      []string `yaml:"extraDirectives"`
 	ExtraIgnores         []string `yaml:"extraIgnores"`
 	ExtraPackages        []string `yaml:"extraPackages"`
+	ExtraTestPackages    []string `yaml:"extraTestPackages"`
 	RunAsRoot            bool     `yaml:"runAsRoot"`
 	UseBuildKit          bool     `yaml:"useBuildKit"`
 	WithLinkerdAwait     bool     `yaml:"withLinkerdAwait"`

--- a/internal/dockerfile/docker.go
+++ b/internal/dockerfile/docker.go
@@ -93,6 +93,7 @@ func RenderConfig(cfg core.Configuration, sr golang.ScanResult) {
 	if sr.UsesPostgres {
 		extraTestPackages = append(extraTestPackages, "postgresql")
 	}
+	extraTestPackages = append(extraTestPackages, cfg.Dockerfile.ExtraTestPackages...)
 
 	must.Succeed(util.WriteFileFromTemplate("Dockerfile", dockerfileTemplate, map[string]any{
 		"Config": cfg,


### PR DESCRIPTION
I created this PR because we have a problem running `golangci-lint` within the docker container, that uses the generated Dockerfile from go-makefile-maker.

<img width="1753" height="297" alt="image" src="https://github.com/user-attachments/assets/c3db5ca0-c98e-4522-a53a-82797f6e9b96" />

Looking at the error in the logs, golangci-lint is failing because github.com/ThalesGroup/crypto11 uses cgo, it needs gcc/cgo available to resolve those types and i have not found another way to add the gcc package in the test stage. I tested the changes and those are working for us.

Add `extraTestPackages` configuration option to allow installing additional Alpine packages specifically in the test stage of the Dockerfile