### PR TITLE
Set REUSE info for `build/**/*` by default

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -11,6 +11,7 @@ path = [
   ".gitignore",
   ".license-scan-overrides.jsonl",
   ".license-scan-rules.json",
+  "build/**/*",
 ]
 SPDX-FileCopyrightText = "SAP SE or an SAP affiliate company"
 SPDX-License-Identifier = "Apache-2.0"

--- a/internal/reuse/reuse.toml.tmpl
+++ b/internal/reuse/reuse.toml.tmpl
@@ -18,6 +18,7 @@ path = [
   ".gitignore",
   ".license-scan-overrides.jsonl",
   ".license-scan-rules.json",
+  "build/**/*",
 ]
 SPDX-FileCopyrightText = "SAP SE or an SAP affiliate company"
 SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
The `build/` directory is populated during `builder` target[^1], and its content is then copied to `test` target[^2] causing the REUSE checks to fail, as the built binaries don't include license information:

```
...
>> reuse lint

The following files have no copyright and licensing information:
* /src/build/server
...
```

1: https://github.com/sapcc/go-makefile-maker/blob/1b951b405ab658a5db76f35f36cf34e98f814085/internal/dockerfile/Dockerfile.tmpl#L24
2: https://github.com/sapcc/go-makefile-maker/blob/1b951b405ab658a5db76f35f36cf34e98f814085/internal/dockerfile/Dockerfile.tmpl#L53
