### PR TITLE
Maintain git `safe.directory` only when it's git repo

### DIFF
--- a/internal/dockerfile/Dockerfile.tmpl
+++ b/internal/dockerfile/Dockerfile.tmpl
@@ -59,7 +59,7 @@ RUN {{ range $dcfg.CheckEnv }}{{ . }} {{ end }}make -C /src static-check
 RUN chown -R 4200:4200 /src/ /go/
 USER 4200:4200
 RUN cd /src \
-  && git config --global --add safe.directory /src \
+  && { test -d .git && git config --global --add safe.directory /src || true; } \
   && {{ range $dcfg.CheckEnv }}{{ . }} {{ end }}make build/cover.out
 
 ################################################################################

--- a/internal/dockerfile/Dockerfile.tmpl
+++ b/internal/dockerfile/Dockerfile.tmpl
@@ -59,7 +59,7 @@ RUN {{ range $dcfg.CheckEnv }}{{ . }} {{ end }}make -C /src static-check
 RUN chown -R 4200:4200 /src/ /go/
 USER 4200:4200
 RUN cd /src \
-  && { test -d .git && git config --global --add safe.directory /src || true; } \
+  && { if test -d .git; then git config --global --add safe.directory /src; fi; } \
   && {{ range $dcfg.CheckEnv }}{{ . }} {{ end }}make build/cover.out
 
 ################################################################################


### PR DESCRIPTION
When `/src` is not a git repository, the `git config` command fails causing the rest of the build to fail too.

There could be a few reasons for `/src` to be not a valid git repo:
- when it was originally a worktree, in which case only `.git` _file_ exists instead, which is enough for regular `git` commands to work on a hostmachine, but causes failures in docker build.
- when `.git` was added into `.dockerignore` to reduce build times (build context transfer)
