### PR TITLE
Allow skipping `test` target in Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ dockerfile:
   enabled: true
   checkEnv:
     - CHECK_SKIPS_FUNCTIONAL_TEST=true
-  skipTestTarget: true # does not include `test` target into the Dockerfile
+  withTestTarget: false # explicit false omits `test` target in the Dockerfile; otherwise the target is always set up
   entrypoint: [ "/bin/bash", "--", "--arg" ]
   extraBuildStages:
     - |

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ dockerfile:
   enabled: true
   checkEnv:
     - CHECK_SKIPS_FUNCTIONAL_TEST=true
+  skipTestTarget: true # does not include `test` target into the Dockerfile
   entrypoint: [ "/bin/bash", "--", "--arg" ]
   extraBuildStages:
     - |

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -300,7 +300,7 @@ type EnvRcConfig struct {
 type DockerfileConfig struct {
 	Enabled              bool         `yaml:"enabled"`
 	CheckEnv             []string     `yaml:"checkEnv"`
-	SkipTestTarget       bool         `yaml:"skipTestTarget"`
+	WithTestTarget       Option[bool]         `yaml:"withTestTarget"`
 	CrossCompile         Option[bool] `yaml:"crossCompile"`
 	Entrypoint           []string     `yaml:"entrypoint"`
 	ExtraBuildDirectives []string     `yaml:"extraBuildDirectives"`

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -300,6 +300,7 @@ type EnvRcConfig struct {
 type DockerfileConfig struct {
 	Enabled              bool         `yaml:"enabled"`
 	CheckEnv             []string     `yaml:"checkEnv"`
+	SkipTestTarget       bool         `yaml:"skipTestTarget"`
 	CrossCompile         Option[bool] `yaml:"crossCompile"`
 	Entrypoint           []string     `yaml:"entrypoint"`
 	ExtraBuildDirectives []string     `yaml:"extraBuildDirectives"`

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -300,7 +300,7 @@ type EnvRcConfig struct {
 type DockerfileConfig struct {
 	Enabled              bool         `yaml:"enabled"`
 	CheckEnv             []string     `yaml:"checkEnv"`
-	SkipTestTarget       bool         `yaml:"skipTestTarget"`
+	WithTestTarget       Option[bool] `yaml:"withTestTarget"`
 	CrossCompile         Option[bool] `yaml:"crossCompile"`
 	Entrypoint           []string     `yaml:"entrypoint"`
 	ExtraBuildDirectives []string     `yaml:"extraBuildDirectives"`

--- a/internal/dockerfile/Dockerfile.tmpl
+++ b/internal/dockerfile/Dockerfile.tmpl
@@ -28,7 +28,7 @@ RUN {{ if .UseBuildKit }}--mount=type=cache,target=/go/pkg/mod \
 
 {{ end -}}
 
-{{ if not .SkipTestTarget -}}
+{{ if .WithTestTarget -}}
 ################################################################################
 
 # To only build the tests run: docker build . --target test

--- a/internal/dockerfile/Dockerfile.tmpl
+++ b/internal/dockerfile/Dockerfile.tmpl
@@ -27,6 +27,8 @@ RUN {{ if .UseBuildKit }}--mount=type=cache,target=/go/pkg/mod \
 {{ . }}
 
 {{ end -}}
+
+{{ if not .SkipTestTarget -}}
 ################################################################################
 
 # To only build the tests run: docker build . --target test
@@ -61,6 +63,7 @@ USER 4200:4200
 RUN cd /src \
   && git config --global --add safe.directory /src \
   && {{ range $dcfg.CheckEnv }}{{ . }} {{ end }}make build/cover.out
+{{ end -}}
 
 ################################################################################
 

--- a/internal/dockerfile/docker.go
+++ b/internal/dockerfile/docker.go
@@ -109,7 +109,7 @@ func RenderConfig(cfg core.Configuration, sr golang.ScanResult) {
 			"DefaultAlpineImage": core.DefaultAlpineImage,
 		},
 		"DockerHubMirror":    dockerHubMirror,
-		"SkipTestTarget":     cfg.Dockerfile.SkipTestTarget,
+		"WithTestTarget":     cfg.Dockerfile.WithTestTarget.UnwrapOr(true),
 		"CheckEnv":           cfg.Dockerfile.CheckEnv,
 		"ExtraTestPackages":  extraTestPackages,
 		"Entrypoint":         entrypoint,

--- a/internal/dockerfile/docker.go
+++ b/internal/dockerfile/docker.go
@@ -109,6 +109,7 @@ func RenderConfig(cfg core.Configuration, sr golang.ScanResult) {
 			"DefaultAlpineImage": core.DefaultAlpineImage,
 		},
 		"DockerHubMirror":    dockerHubMirror,
+		"SkipTestTarget":     cfg.Dockerfile.SkipTestTarget,
 		"CheckEnv":           cfg.Dockerfile.CheckEnv,
 		"ExtraTestPackages":  extraTestPackages,
 		"Entrypoint":         entrypoint,


### PR DESCRIPTION
When using BuildKit is not an option, `test` target is still being executed all the time during the image build even though `test` outputs are not needed for the final image. And if the image needs to be run as part of development iteration it makes the whole development experience frustrating.

An example would be to spin up a respective project service in a container (e.g. using https://testcontainers.com/, which doesn't support BuildKit as a matter of fact) and execute a test suite against the running container.

Given that `go-makefile-maker` adds GHA workflows with the same tests, it's supposedly most often the case than not, that the tests are executed by the respective GHA workflow before the image could be built - making the same `test` target execution of lower value, or relevant  for other contexts (is it for those who prefer to isolate all the   checking tooling inside a container?).
