### PR TITLE
[goreleaser] DEPRECATED: archives.format should not be used anymore

### DIFF
--- a/internal/goreleaser/goreleaser.yaml.tmpl
+++ b/internal/goreleaser/goreleaser.yaml.tmpl
@@ -6,7 +6,7 @@ version: 2
 archives:
   - name_template: '{{ .nameTemplate }}'
 {{- if .format }}
-    format: {{ .format }}
+    formats: [ {{ .format }} ]
 {{- end }}
     format_overrides:
       - goos: windows


### PR DESCRIPTION
Replaced by archives.formats:
https://goreleaser.com/deprecations#archivesformat
