### PR TITLE
fix(ci): pass root-package to go-coverage-report for /v2+ modules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,7 @@ jobs:
         with:
           coverage-artifact-name: code-coverage
           coverage-file-name: cover.out
+          root-package: github.com/sapcc/go-makefile-maker
     permissions:
       actions: read
       contents: read

--- a/internal/ghworkflow/workflow_ci.go
+++ b/internal/ghworkflow/workflow_ci.go
@@ -79,13 +79,17 @@ func ciWorkflow(cfg core.Configuration, sr golang.ScanResult) {
 			Actions:      "read",
 			PullRequests: "write",
 		}
+		with := map[string]any{
+			"coverage-artifact-name": coverageArtifactName,
+			"coverage-file-name":     "cover.out",
+		}
+		if sr.ModulePath != "" {
+			with["root-package"] = sr.ModulePath
+		}
 		codeCov.addStep(jobStep{
 			Name: "Post coverage report",
 			Uses: core.GoCoverageReportAction,
-			With: map[string]any{
-				"coverage-artifact-name": coverageArtifactName,
-				"coverage-file-name":     "cover.out",
-			},
+			With: with,
 		})
 		w.Jobs["code_coverage"] = codeCov
 	}


### PR DESCRIPTION
The `fgrosse/go-coverage-report` action defaults `root-package` to `github.com/${{ github.repository }}`, which doesn't match the `cover.out` entries for modules with a `/vN` major-version suffix (e.g. `github.com/sapcc/archer/v2`). Result: every changed file reports `0/0/0` statements and the coverage comment is silently useless — the CI job itself succeeds, so the regression is invisible.

Pass the module path from `go.mod` (already available as `ScanResult.ModulePath` at the call site) explicitly, guarded by a non-empty check so non-Go consumers are unaffected. This fixes the bug for every current and future `/vN` consumer without introducing a new config knob.

Confirmed downstream against `sapcc/archer` (`github.com/sapcc/archer/v2`, broken since PR #757) — regenerated workflow now emits `root-package: github.com/sapcc/archer/v2`. Behavior for non-suffix modules is unchanged in effect (the new line matches what the action would have defaulted to).