### PR TITLE
properly ignore GitHub action version updates in non-gomm repos

### DIFF
--- a/internal/ghworkflow/render.go
+++ b/internal/ghworkflow/render.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"go.yaml.in/yaml/v3"
-
 	"github.com/sapcc/go-bits/logg"
 	"github.com/sapcc/go-bits/must"
+	. "go.xyrillian.de/gg/option"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/sapcc/go-makefile-maker/internal/core"
 	"github.com/sapcc/go-makefile-maker/internal/golang"
@@ -20,7 +20,8 @@ import (
 const workflowDir = ".github/workflows"
 
 // Render renders GitHub workflows.
-func Render(cfg core.Configuration, sr golang.ScanResult) {
+// Returns a list of filenames for all files that were generated.
+func Render(cfg core.Configuration, sr golang.ScanResult) []string {
 	ghwCfg := cfg.GitHubWorkflow
 
 	must.Succeed(os.MkdirAll(workflowDir, 0o755))
@@ -32,17 +33,28 @@ func Render(cfg core.Configuration, sr golang.ScanResult) {
 	must.Succeed(os.RemoveAll(filepath.Join(workflowDir, "spell.yaml")))
 
 	// TODO: checking on GoVersion is only an aid until we can properly detect rust applications
+	var allWorkflows []Option[workflow]
 	if sr.GoVersion != "" {
-		checksWorkflow(cfg)
-		ciWorkflow(cfg, sr)
-		codeQLWorkflow(cfg)
+		allWorkflows = append(allWorkflows, checksWorkflow(cfg))
+		allWorkflows = append(allWorkflows, ciWorkflow(cfg, sr))
+		allWorkflows = append(allWorkflows, codeQLWorkflow(cfg))
 	}
-	helmWorkflow(cfg)
-	ghcrWorkflow(ghwCfg)
-	releaseWorkflow(cfg)
+	allWorkflows = append(allWorkflows, helmWorkflow(cfg))
+	allWorkflows = append(allWorkflows, ghcrWorkflow(ghwCfg))
+	allWorkflows = append(allWorkflows, releaseWorkflow(cfg))
+
+	var result []string
+	for _, workflowOrNone := range allWorkflows {
+		w, ok := workflowOrNone.Unpack()
+		if ok {
+			writeWorkflowToFile(w)
+			result = append(result, w.getPath())
+		}
+	}
+	return result
 }
 
-func writeWorkflowToFile(w *workflow) {
+func writeWorkflowToFile(w workflow) {
 	path := w.getPath()
 	logg.Debug("-> writing file %s", path)
 	f := must.Return(os.Create(path))

--- a/internal/ghworkflow/workflow.go
+++ b/internal/ghworkflow/workflow.go
@@ -13,8 +13,8 @@ import (
 	"github.com/sapcc/go-makefile-maker/internal/util"
 )
 
-func newWorkflow(name, defaultBranch string, ignorePaths []string) *workflow {
-	return &workflow{
+func newWorkflow(name, defaultBranch string, ignorePaths []string) workflow {
+	return workflow{
 		Name: name,
 		On:   pushAndPRTriggers(defaultBranch, ignorePaths),
 		Permissions: permissions{
@@ -39,7 +39,7 @@ func (w workflow) getPath() string {
 	return filepath.Join(workflowDir, fileName+".yaml")
 }
 
-func (w workflow) deleteIf(condition bool) bool {
+func (w workflow) deleteUnless(condition bool) bool {
 	if !condition {
 		must.Succeed(os.RemoveAll(w.getPath()))
 		return true

--- a/internal/ghworkflow/workflow_checks.go
+++ b/internal/ghworkflow/workflow_checks.go
@@ -4,11 +4,13 @@
 package ghworkflow
 
 import (
+	. "go.xyrillian.de/gg/option"
+
 	"github.com/sapcc/go-makefile-maker/internal/core"
 )
 
 // basically a collection of other linters and checks which run fast to reduce the amount of created githbu action workflows
-func checksWorkflow(cfg core.Configuration) {
+func checksWorkflow(cfg core.Configuration) Option[workflow] {
 	ghwCfg := cfg.GitHubWorkflow
 	w := newWorkflow("Checks", ghwCfg.Global.DefaultBranch, nil)
 	w.On.WorkflowDispatch.manualTrigger = true
@@ -68,6 +70,5 @@ func checksWorkflow(cfg core.Configuration) {
 	}
 
 	w.Jobs = map[string]job{"checks": j}
-
-	writeWorkflowToFile(w)
+	return Some(w)
 }

--- a/internal/ghworkflow/workflow_ci.go
+++ b/internal/ghworkflow/workflow_ci.go
@@ -6,11 +6,13 @@ package ghworkflow
 import (
 	"fmt"
 
+	. "go.xyrillian.de/gg/option"
+
 	"github.com/sapcc/go-makefile-maker/internal/core"
 	"github.com/sapcc/go-makefile-maker/internal/golang"
 )
 
-func ciWorkflow(cfg core.Configuration, sr golang.ScanResult) {
+func ciWorkflow(cfg core.Configuration, sr golang.ScanResult) Option[workflow] {
 	ghwCfg := cfg.GitHubWorkflow
 	ignorePaths := ghwCfg.CI.IgnorePaths
 	if len(ignorePaths) == 0 {
@@ -21,8 +23,8 @@ func ciWorkflow(cfg core.Configuration, sr golang.ScanResult) {
 	w.On.WorkflowDispatch.manualTrigger = true
 	w.On.Push.Branches = []string{ghwCfg.Global.DefaultBranch}
 
-	if w.deleteIf(ghwCfg.CI.Enabled) {
-		return
+	if w.deleteUnless(ghwCfg.CI.Enabled) {
+		return None[workflow]()
 	}
 
 	w.Jobs = make(map[string]job)
@@ -94,5 +96,5 @@ func ciWorkflow(cfg core.Configuration, sr golang.ScanResult) {
 		w.Jobs["code_coverage"] = codeCov
 	}
 
-	writeWorkflowToFile(w)
+	return Some(w)
 }

--- a/internal/ghworkflow/workflow_codeql.go
+++ b/internal/ghworkflow/workflow_codeql.go
@@ -4,16 +4,18 @@
 package ghworkflow
 
 import (
+	. "go.xyrillian.de/gg/option"
+
 	"github.com/sapcc/go-makefile-maker/internal/core"
 )
 
-func codeQLWorkflow(cfg core.Configuration) {
+func codeQLWorkflow(cfg core.Configuration) Option[workflow] {
 	ghwCfg := cfg.GitHubWorkflow
 	w := newWorkflow("CodeQL", ghwCfg.Global.DefaultBranch, nil)
 	w.On.WorkflowDispatch.manualTrigger = true
 
-	if w.deleteIf(ghwCfg.SecurityChecks.IsEnabled()) {
-		return
+	if w.deleteUnless(ghwCfg.SecurityChecks.IsEnabled()) {
+		return None[workflow]()
 	}
 
 	w.Permissions.Actions = tokenScopeRead         // for github/codeql-action/init to get workflow details
@@ -41,7 +43,7 @@ func codeQLWorkflow(cfg core.Configuration) {
 		Name: "Perform CodeQL Analysis",
 		Uses: core.GetCodeqlAnalyzeAction(ghwCfg.IsSelfHostedRunner),
 	})
-	w.Jobs = map[string]job{"analyze": j}
 
-	writeWorkflowToFile(w)
+	w.Jobs = map[string]job{"analyze": j}
+	return Some(w)
 }

--- a/internal/ghworkflow/workflow_ghcr.go
+++ b/internal/ghworkflow/workflow_ghcr.go
@@ -8,16 +8,17 @@ import (
 	"strings"
 
 	"github.com/sapcc/go-bits/logg"
+	. "go.xyrillian.de/gg/option"
 
 	"github.com/sapcc/go-makefile-maker/internal/core"
 )
 
-func ghcrWorkflow(cfg *core.GithubWorkflowConfiguration) {
+func ghcrWorkflow(cfg *core.GithubWorkflowConfiguration) Option[workflow] {
 	// https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#publishing-a-package-using-an-action
 	w := newWorkflow("Container Registry GHCR", cfg.Global.DefaultBranch, nil)
 
-	if w.deleteIf(cfg.PushContainerToGhcr.Enabled) {
-		return
+	if w.deleteUnless(cfg.PushContainerToGhcr.Enabled) {
+		return None[workflow]()
 	}
 
 	w.Permissions.Contents = tokenScopeRead
@@ -120,7 +121,7 @@ type=sha,format=long
 			"platforms": platforms,
 		},
 	})
-	w.Jobs = map[string]job{"build-and-push-image": j}
 
-	writeWorkflowToFile(w)
+	w.Jobs = map[string]job{"build-and-push-image": j}
+	return Some(w)
 }

--- a/internal/ghworkflow/workflow_helm.go
+++ b/internal/ghworkflow/workflow_helm.go
@@ -7,16 +7,18 @@ import (
 	"slices"
 	"strings"
 
+	. "go.xyrillian.de/gg/option"
+
 	"github.com/sapcc/go-makefile-maker/internal/core"
 )
 
-func helmWorkflow(cfg core.Configuration) {
+func helmWorkflow(cfg core.Configuration) Option[workflow] {
 	// https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#publishing-a-package-using-an-action
 	w := newWorkflow("Helm OCI Package GHCR", cfg.GitHubWorkflow.Global.DefaultBranch, nil)
 
-	if w.deleteIf(cfg.GitHubWorkflow.PushHelmChartToGhcr.Path.IsSome() &&
+	if w.deleteUnless(cfg.GitHubWorkflow.PushHelmChartToGhcr.Path.IsSome() &&
 		strings.HasPrefix(cfg.Metadata.URL, "https://github.com")) {
-		return
+		return None[workflow]()
 	}
 
 	var helmConfig = cfg.GitHubWorkflow.PushHelmChartToGhcr
@@ -120,7 +122,7 @@ func helmWorkflow(cfg core.Configuration) {
 		Name: "Push Helm Chart to " + registry,
 		Run:  "helm push ./chart/*.tgz oci://" + registry + "/${{ github.repository_owner }}/charts",
 	})
-	w.Jobs = map[string]job{"build-and-push-helm-package": j}
 
-	writeWorkflowToFile(w)
+	w.Jobs = map[string]job{"build-and-push-helm-package": j}
+	return Some(w)
 }

--- a/internal/ghworkflow/workflow_release.go
+++ b/internal/ghworkflow/workflow_release.go
@@ -3,15 +3,19 @@
 
 package ghworkflow
 
-import "github.com/sapcc/go-makefile-maker/internal/core"
+import (
+	. "go.xyrillian.de/gg/option"
 
-func releaseWorkflow(cfg core.Configuration) {
+	"github.com/sapcc/go-makefile-maker/internal/core"
+)
+
+func releaseWorkflow(cfg core.Configuration) Option[workflow] {
 	// https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#publishing-a-package-using-an-action
 	ghwCfg := cfg.GitHubWorkflow
 	w := newWorkflow("goreleaser", ghwCfg.Global.DefaultBranch, nil)
 
-	if w.deleteIf(ghwCfg.Release.Enabled.UnwrapOr(cfg.GoReleaser.ShouldCreateConfig())) {
-		return
+	if w.deleteUnless(ghwCfg.Release.Enabled.UnwrapOr(cfg.GoReleaser.ShouldCreateConfig())) {
+		return None[workflow]()
 	}
 
 	w.Permissions.Contents = tokenScopeWrite
@@ -49,7 +53,7 @@ func releaseWorkflow(cfg core.Configuration) {
 			"GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}",
 		},
 	})
-	w.Jobs = map[string]job{"release": j}
 
-	writeWorkflowToFile(w)
+	w.Jobs = map[string]job{"release": j}
+	return Some(w)
 }

--- a/internal/renovate/renovate.go
+++ b/internal/renovate/renovate.go
@@ -40,7 +40,7 @@ type config struct {
 }
 
 // RenderConfig writes the renovate configuration files from the provided config and scan results.
-func RenderConfig(cfg core.Configuration, scanResult golang.ScanResult) {
+func RenderConfig(cfg core.Configuration, scanResult golang.ScanResult, generatedGHWorkflowPaths []string) {
 	isGoMakefileMakerRepo := scanResult.ModulePath == "github.com/sapcc/go-makefile-maker"
 	isInternalRenovate := strings.HasPrefix(cfg.Metadata.URL, "https://github.wdf.sap.corp")
 
@@ -135,6 +135,11 @@ func RenderConfig(cfg core.Configuration, scanResult golang.ScanResult) {
 		renovateConfig.Extends = append(renovateConfig.Extends, "docker:enableMajor", "customManagers:dockerfileVersions")
 	} else {
 		renovateConfig.Extends = append(renovateConfig.Extends, "docker:disable")
+		renovateConfig.PackageRules = append(renovateConfig.PackageRules, core.PackageRule{
+			MatchDepTypes:  []string{"action"},
+			MatchFileNames: generatedGHWorkflowPaths,
+			Enabled:        Some(false),
+		})
 	}
 	if scanResult.HasKubernetesDeps {
 		renovateConfig.PackageRules = append(renovateConfig.PackageRules, core.PackageRule{

--- a/main.go
+++ b/main.go
@@ -116,9 +116,10 @@ func main() {
 	}
 
 	// Render GitHub workflows
+	var ghworkflowPaths []string
 	if cfg.GitHubWorkflow != nil {
 		logg.Debug("rendering GitHub Actions workflows")
-		ghworkflow.Render(cfg, sr)
+		ghworkflowPaths = ghworkflow.Render(cfg, sr)
 	}
 
 	// Render envrc file
@@ -130,7 +131,7 @@ func main() {
 		if cfg.Renovate.GoVersion == "" {
 			cfg.Renovate.GoVersion = sr.GoVersionMajorMinor
 		}
-		renovate.RenderConfig(cfg, sr)
+		renovate.RenderConfig(cfg, sr, ghworkflowPaths)
 	}
 
 	// Render REUSE config file


### PR DESCRIPTION
This fixes the hallucinated config that was added in #528 and reverted in #529.

- To ensure that updates are only blocked for files that are managed by go-makefile-maker (not for repo-specific custom actions like the "run-conformance-test" action in Keppel), the rendering step for `.github/workflows` now returns a list of all generated files, which is used as an input when rendering the Renovate config.
- While touching this part of the code, I noticed that `workflow.deleteIf()` is named in a misleading manner. I renamed it to `workflow.deleteUnless()` to clarify its semantics. This is not a behavioral change; it was used in the right way and just looked wrong.

For reference, this is the diff of what this change does in other repos (tested in the Keppel repo), vs. the state brought upon us by #528:

```patch
diff --git a/.github/renovate.json b/.github/renovate.json
index 927ebf1c9a..a57b6bc1d4 100644
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,8 +4,7 @@
     "config:recommended",
     "default:pinDigestsDisabled",
     "mergeConfidence:all-badges",
-    "docker:disable",
-    "github-actions:disable"
+    "docker:disable"
   ],
   "assignees": [
     "majewsky",
@@ -60,6 +59,17 @@
       ],
       "dependencyDashboardApproval": true
     },
+    {
+      "matchDepTypes": [
+        "action"
+      ],
+      "matchFileNames": [
+        ".github/workflows/checks.yaml",
+        ".github/workflows/ci.yaml",
+        ".github/workflows/codeql.yaml"
+      ],
+      "enabled": false
+    },
     {
       "matchDepTypes": [
         "action"
```