### PR TITLE
Add releasePR option for PR-driven release automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,6 +770,45 @@ If `release` is enabled a workflow is generated which creates a new GitHub relea
 
 `goReleaser.createConfig` will be set to true automatically when the option isn't set yet.
 
+#### `githubWorkflow.release.releasePR`
+
+Automatically create a release PR to bump the version and changelog whenever there are unreleased changes in the `CHANGELOG.md` file.
+This allows you to have a human in the loop for releases without having to manually prepare the release PR,
+and ensures that the release commit message contains the changelog entries.
+
+`releasePR` defaults to `true` whenever the release workflow is rendered. Set it to `false` to opt out.
+
+##### Flow
+1. Whenever the `[Unreleased]` section of `CHANGELOG.md` has content, the `release-pr` workflow opens (or updates)
+   a PR on the `chore/release-next` branch that bumps the changelog and version.
+2. Merging that PR triggers a new `tag` job in the `goreleaser` workflow which creates and pushes the release tag,
+   after which the existing `release` job runs goreleaser.
+
+##### Choosing the version bump
+
+By default the `release-pr` workflow runs on every push to the default branch and bumps the **patch** version.
+To cut a minor or major release, trigger the workflow manually:
+
+1. Open the **Actions** tab on GitHub and pick the **release-pr** workflow.
+2. Click **Run workflow**.
+3. In the dropdown, select the desired `version` bump (`patch`, `minor`, or `major`) and confirm.
+
+The dispatched run replaces the default patch bump for that release PR; the resulting commit and tag will use
+the selected bump type.
+
+##### Project-specific release preparation
+
+If your project needs additional steps during the version bump (regenerating generated files, bumping version strings
+in other manifests, etc.), define a `release-prepare` target in your `Makefile` (for example via `verbatim:`).
+The `release-pr` workflow will run `make release-prepare` automatically when the target exists.
+
+```yaml
+githubWorkflow:
+  release:
+    enabled: true
+    # releasePR: false   # opt out of PR-driven releases
+```
+
 #### `githubWorkflow.securityChecks`
 
 If `securityChecks` is enabled then it will generate the following workflows:

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -233,6 +233,8 @@ type PushHelmChartToGhcrConfig struct {
 // ReleaseWorkflowConfig appears in type ReleaseWorkflowConfig.
 type ReleaseWorkflowConfig struct {
 	Enabled Option[bool] `yaml:"enabled"`
+	// ReleasePR opts into PR-driven release automation. Defaults to true.
+	ReleasePR Option[bool] `yaml:"releasePR"`
 }
 
 // SecurityChecksWorkflowConfig appears in type Configuration.
@@ -455,6 +457,13 @@ func (c *Configuration) Validate() {
 			if len(ghwCfg.CI.RunsOn) > 1 && !strings.HasPrefix(ghwCfg.CI.RunsOn[0], "ubuntu") {
 				logg.Fatal("githubWorkflow.ci.runOn must only define a single Ubuntu based runner when githubWorkflow.ci.enabled is true")
 			}
+		}
+
+		// Validate Release workflow configuration. Only flag explicit `releasePR: true`
+		// without a release workflow being rendered; the default-on case is silently
+		// inert when the release workflow itself is disabled.
+		if ghwCfg.Release.ReleasePR.UnwrapOr(false) && !ghwCfg.Release.Enabled.UnwrapOr(c.GoReleaser.ShouldCreateConfig()) {
+			logg.Fatal("githubWorkflow.release.releasePR requires githubWorkflow.release.enabled (or goReleaser.createConfig) to be true")
 		}
 	}
 

--- a/internal/core/constants.go
+++ b/internal/core/constants.go
@@ -71,12 +71,14 @@ const (
 	DockerQemuAction      = util.RawString("docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4")
 	DockerBuildPushAction = util.RawString("docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7")
 
-	DownloadSyftAction     = util.RawString("anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0")
-	GoCoverageReportAction = util.RawString("fgrosse/go-coverage-report@cbeb2ab2e32591d690337146ba02a911cc566f3f # v1.3.0")
-	GolangCiLintVersion    = "v2.12.2"
-	GolangciLintAction     = util.RawString("golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9")
-	GoreleaserAction       = util.RawString("goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7")
-	ReuseAction            = util.RawString("fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6")
-	TyposAction            = util.RawString("crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # v1")
-	HelmSetupAction        = util.RawString("azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5")
+	CreatePullRequestAction = util.RawString("peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1")
+	DownloadSyftAction      = util.RawString("anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0")
+	GoCoverageReportAction  = util.RawString("fgrosse/go-coverage-report@cbeb2ab2e32591d690337146ba02a911cc566f3f # v1.3.0")
+	GolangCiLintVersion     = "v2.12.2"
+	GolangciLintAction      = util.RawString("golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9")
+	GoreleaserAction        = util.RawString("goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7")
+	KeepAChangelogAction    = util.RawString("release-flow/keep-a-changelog-action@74931dec7ecdbfc8e38ac9ae7e8dd84c08db2f32 # v3.0.0")
+	ReuseAction             = util.RawString("fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6")
+	TyposAction             = util.RawString("crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # v1")
+	HelmSetupAction         = util.RawString("azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5")
 )

--- a/internal/ghworkflow/render.go
+++ b/internal/ghworkflow/render.go
@@ -42,6 +42,7 @@ func Render(cfg core.Configuration, sr golang.ScanResult) []string {
 	allWorkflows = append(allWorkflows, helmWorkflow(cfg))
 	allWorkflows = append(allWorkflows, ghcrWorkflow(ghwCfg))
 	allWorkflows = append(allWorkflows, releaseWorkflow(cfg))
+	allWorkflows = append(allWorkflows, releasePRWorkflow(cfg))
 
 	var result []string
 	for _, workflowOrNone := range allWorkflows {

--- a/internal/ghworkflow/workflow.go
+++ b/internal/ghworkflow/workflow.go
@@ -86,15 +86,26 @@ type pushAndPRTriggerOpts struct {
 	Paths       []string `yaml:"paths,omitempty"`
 	PathsIgnore []string `yaml:"paths-ignore,omitempty"`
 	Tags        []string `yaml:"tags,omitempty"`
+	Types       []string `yaml:"types,omitempty"`
 }
 
 type workflowDispatch struct {
-	manualTrigger bool `yaml:"-"`
+	manualTrigger bool                             `yaml:"-"`
+	Inputs        map[string]workflowDispatchInput `yaml:"inputs,omitempty"`
+}
+
+// workflowDispatchInput models a single input definition under workflow_dispatch.inputs.
+type workflowDispatchInput struct {
+	Description string   `yaml:"description,omitempty"`
+	Required    bool     `yaml:"required,omitempty"`
+	Default     string   `yaml:"default,omitempty"`
+	Type        string   `yaml:"type,omitempty"`
+	Options     []string `yaml:"options,omitempty"`
 }
 
 // IsZero defines whether a workflowDispatch is zero (not set).
 func (w workflowDispatch) IsZero() bool {
-	return !w.manualTrigger
+	return !w.manualTrigger && len(w.Inputs) == 0
 }
 
 type job struct {
@@ -116,6 +127,10 @@ type job struct {
 
 	// A map of environment variables that are available to all steps in the job.
 	Env map[string]string `yaml:"env,omitempty"`
+
+	// A map of outputs for the job. Outputs are available to downstream jobs
+	// that depend on this job via `needs.<job_id>.outputs.<output_name>`.
+	Outputs map[string]string `yaml:"outputs,omitempty"`
 
 	// Steps can run commands, run setup tasks, or run an action. Not all steps
 	// run actions, but all actions run as a step. Each step runs in its own

--- a/internal/ghworkflow/workflow_release.go
+++ b/internal/ghworkflow/workflow_release.go
@@ -9,6 +9,11 @@ import (
 	"github.com/sapcc/go-makefile-maker/internal/core"
 )
 
+// releasePRBranch is the branch name used by the release-pr workflow when it
+// opens or updates the release PR; the goreleaser workflow's tag job uses the
+// same value to filter for that PR's merge event.
+const releasePRBranch = "chore/release-next"
+
 func releaseWorkflow(cfg core.Configuration) Option[workflow] {
 	// https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#publishing-a-package-using-an-action
 	ghwCfg := cfg.GitHubWorkflow
@@ -18,17 +23,36 @@ func releaseWorkflow(cfg core.Configuration) Option[workflow] {
 		return None[workflow]()
 	}
 
+	releasePR := ghwCfg.Release.ReleasePR.UnwrapOr(true)
+
 	w.Permissions.Contents = tokenScopeWrite
 	w.Permissions.Packages = tokenScopeWrite
 
 	w.On.Push.Branches = nil
 	w.On.PullRequest.Branches = nil
 	w.On.Push.Tags = []string{"*"} // goreleaser uses semver to decide if this is a prerelease or not
+	if releasePR {
+		// Also fire when the release PR is closed; the tag job below filters for
+		// merged PRs from chore/release-next and creates the tag in-process so we
+		// stay within a single workflow run (the default GITHUB_TOKEN cannot
+		// trigger another workflow via tag push).
+		w.On.PullRequest.Branches = []string{ghwCfg.Global.DefaultBranch}
+		w.On.PullRequest.Types = []string{"closed"}
+	}
 
 	j := baseJobWithGo("goreleaser", cfg)
 	// This is needed because: https://goreleaser.com/ci/actions/#fetch-depthness
 	j.Steps[0].With = map[string]any{
 		"fetch-depth": 0,
+	}
+	if releasePR {
+		j.Needs = []string{"tag"}
+		// Run on direct tag pushes OR after the tag job successfully created a tag
+		// (always() so this job is reached on push events that skip the tag job).
+		j.If = "always() && (github.event_name == 'push' || needs.tag.result == 'success')"
+		// On the pull_request path, check out the freshly-pushed tag instead of
+		// the PR merge commit so goreleaser sees the right ref.
+		j.Steps[0].With["ref"] = "${{ github.event_name == 'pull_request' && format('refs/tags/v{0}', needs.tag.outputs.version) || github.ref }}"
 	}
 	j.addStep(jobStep{
 		Name: "Install syft",
@@ -55,5 +79,49 @@ func releaseWorkflow(cfg core.Configuration) Option[workflow] {
 	})
 
 	w.Jobs = map[string]job{"release": j}
+	if releasePR {
+		w.Jobs["tag"] = tagJob(ghwCfg)
+	}
 	return Some(w)
+}
+
+// tagJob creates the job that runs on the release-PR merge event; it reads the
+// version from the CHANGELOG and pushes a tag, after which the goreleaser job
+// (depending on it) runs in the same workflow run.
+func tagJob(ghwCfg *core.GithubWorkflowConfiguration) job {
+	tj := baseJob("tag", ghwCfg)
+	tj.If = "github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.head.ref == '" + releasePRBranch + "'"
+	tj.Outputs = map[string]string{
+		"version": "${{ steps.version.outputs.version }}",
+	}
+	// Need full history to push the tag.
+	tj.Steps[0].With = map[string]any{
+		"fetch-depth": 0,
+	}
+	tj.addStep(jobStep{
+		Name: "Read version from CHANGELOG",
+		ID:   "version",
+		Uses: core.KeepAChangelogAction,
+		With: map[string]any{
+			"command": "query",
+			"version": "latest",
+		},
+	})
+	tj.addStep(jobStep{
+		Name: "Create and push tag",
+		Env: map[string]string{
+			"VERSION": "v${{ steps.version.outputs.version }}",
+		},
+		Run: makeMultilineYAMLString([]string{
+			`if git rev-parse "${VERSION}" >/dev/null 2>&1; then`,
+			`  echo "Tag ${VERSION} already exists, skipping"`,
+			`  exit 0`,
+			`fi`,
+			`git config user.name "github-actions[bot]"`,
+			`git config user.email "41898282+github-actions[bot]@users.noreply.github.com"`,
+			`git tag -a "${VERSION}" -m "Release ${VERSION}"`,
+			`git push origin "${VERSION}"`,
+		}),
+	})
+	return tj
 }

--- a/internal/ghworkflow/workflow_release_pr.go
+++ b/internal/ghworkflow/workflow_release_pr.go
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package ghworkflow
+
+import (
+	. "go.xyrillian.de/gg/option"
+
+	"github.com/sapcc/go-makefile-maker/internal/core"
+)
+
+// releasePRWorkflow renders .github/workflows/release-pr.yaml when the
+// release-PR automation is opted in. See README for details.
+func releasePRWorkflow(cfg core.Configuration) Option[workflow] {
+	ghwCfg := cfg.GitHubWorkflow
+	w := newWorkflow("release-pr", ghwCfg.Global.DefaultBranch, nil)
+
+	enabled := ghwCfg.Release.Enabled.UnwrapOr(cfg.GoReleaser.ShouldCreateConfig()) && ghwCfg.Release.ReleasePR.UnwrapOr(true)
+	if w.deleteUnless(enabled) {
+		return None[workflow]()
+	}
+
+	w.Permissions.Contents = tokenScopeWrite
+	w.Permissions.PullRequests = tokenScopeWrite
+
+	w.On.Push.Branches = []string{ghwCfg.Global.DefaultBranch}
+	w.On.PullRequest.Branches = nil
+	w.On.WorkflowDispatch.Inputs = map[string]workflowDispatchInput{
+		"version": {
+			Description: "Version bump type",
+			Required:    true,
+			Default:     "patch",
+			Type:        "choice",
+			Options:     []string{"patch", "minor", "major"},
+		},
+	}
+
+	j := baseJob("draft-release", ghwCfg)
+	j.Steps[0].With = map[string]any{
+		"fetch-depth": 0,
+	}
+
+	j.addStep(jobStep{
+		Name: "Check for unreleased changes",
+		ID:   "changelog",
+		Uses: core.KeepAChangelogAction,
+		With: map[string]any{
+			"command": "query",
+			"version": "unreleased",
+		},
+	})
+	j.addStep(jobStep{
+		Name: "Check if unreleased section has content",
+		ID:   "check",
+		Env: map[string]string{
+			"RELEASE_NOTES": "${{ steps.changelog.outputs.release-notes }}",
+		},
+		Run: makeMultilineYAMLString([]string{
+			`if [ -n "$RELEASE_NOTES" ]; then`,
+			`  echo "has_changes=true" >> "$GITHUB_OUTPUT"`,
+			`else`,
+			`  echo "has_changes=false" >> "$GITHUB_OUTPUT"`,
+			`fi`,
+		}),
+	})
+	hasChanges := "steps.check.outputs.has_changes == 'true'"
+	j.addStep(jobStep{
+		Name: "Bump changelog",
+		ID:   "bump",
+		If:   hasChanges,
+		Uses: core.KeepAChangelogAction,
+		With: map[string]any{
+			"command":                 "bump",
+			"version":                 "${{ inputs.version || 'patch' }}",
+			"keep-unreleased-section": true,
+		},
+	})
+	j.addStep(jobStep{
+		Name: "Run release-prepare make target (if defined)",
+		If:   hasChanges,
+		Env: map[string]string{
+			"VERSION": "${{ steps.bump.outputs.version }}",
+		},
+		// Project-specific extension hook: if the project's Makefile defines a
+		// `release-prepare` target, run it. Projects use it for things like
+		// regenerating swagger or bumping web/package.json. We probe with
+		// `make -n` (dry-run) to avoid failing when the target does not exist.
+		Run: makeMultilineYAMLString([]string{
+			`if make -n release-prepare >/dev/null 2>&1; then`,
+			`  make release-prepare`,
+			`else`,
+			`  echo "No release-prepare target defined; skipping."`,
+			`fi`,
+		}),
+	})
+	j.addStep(jobStep{
+		Name: "Create or update pull request",
+		If:   hasChanges,
+		Uses: core.CreatePullRequestAction,
+		With: map[string]any{
+			"branch":         releasePRBranch,
+			"base":           ghwCfg.Global.DefaultBranch,
+			"commit-message": "chore: release v${{ steps.bump.outputs.version }}",
+			"title":          "chore: release v${{ steps.bump.outputs.version }}",
+			"body":           releasePRBody,
+			"labels":         "release",
+		},
+	})
+
+	w.Jobs = map[string]job{"draft-release": j}
+
+	return Some(w)
+}
+
+const releasePRBody = `Automated release PR for v${{ steps.bump.outputs.version }}.
+
+Merging this PR will tag the release and trigger goreleaser.
+
+### Release Notes
+
+${{ steps.bump.outputs.release-notes }}
+`

--- a/internal/goreleaser/RELEASE.md.tmpl
+++ b/internal/goreleaser/RELEASE.md.tmpl
@@ -6,7 +6,34 @@ SPDX-License-Identifier: Apache-2.0
 # Release Guide
 
 We use [GoReleaser][goreleaser] and GitHub workflows for automating the release
-process. Follow the instructions below for creating a new release.
+process. We follow [semantic versioning][semver].
+
+{{ if .releasePR -}}
+This repository uses **PR-driven releases**: pushes to `{{ .branch }}` trigger a
+`release-pr` workflow that opens (or updates) a release PR with a changelog and
+version bump. Merging that PR tags and publishes the release automatically.
+
+## Cutting a release
+
+1. Land your changes on `{{ .branch }}` with entries under the `[Unreleased]`
+   section of [`CHANGELOG.md`](./CHANGELOG.md).
+
+2. Find the release PR opened by the `release-pr` workflow on branch
+   `chore/release-next`. By default it prepares a **patch** bump.
+   For a **minor** or **major** release, open the **Actions** tab, pick the
+   **release-pr** workflow, click **Run workflow**, and select the desired
+   bump from the `version` dropdown (`patch` / `minor` / `major`).
+
+3. Review and merge the PR. The `goreleaser` workflow's `tag` job creates and
+   pushes the `vX.Y.Z` tag, and the `release` job runs goreleaser to publish.
+
+If you need to cut a release without going through the release PR (e.g. to
+re-tag), you can fall back to the [manual flow](#manual-flow) below.
+
+## Manual flow
+{{- else }}
+## Cutting a release
+{{- end }}
 
 1. Ensure local `{{ .branch }}` branch is up to date with `origin/{{ .branch }}`:
 

--- a/internal/goreleaser/goreleaser.go
+++ b/internal/goreleaser/goreleaser.go
@@ -73,6 +73,12 @@ func RenderConfig(cfg core.Configuration) {
 		branch = cfg.GitHubWorkflow.Global.DefaultBranch
 	}
 
+	releasePR := false
+	if cfg.GitHubWorkflow != nil {
+		releaseEnabled := cfg.GitHubWorkflow.Release.Enabled.UnwrapOr(cfg.GoReleaser.ShouldCreateConfig())
+		releasePR = releaseEnabled && cfg.GitHubWorkflow.Release.ReleasePR.UnwrapOr(true)
+	}
+
 	must.Succeed(util.WriteFileFromTemplate(".goreleaser.yaml", goreleaserTemplate, map[string]any{
 		"nameTemplate": nameTemplate,
 		"format":       cfg.GoReleaser.Format,
@@ -84,6 +90,7 @@ func RenderConfig(cfg core.Configuration) {
 		"githubDomain": metadataURL,
 	}))
 	must.Succeed(util.WriteFileFromTemplate("RELEASE.md", releaseMDTemplate, map[string]any{
-		"branch": branch,
+		"branch":    branch,
+		"releasePR": releasePR,
 	}))
 }


### PR DESCRIPTION
Hi,

I was looking into better automated cutting releases. Go-makefile-maker heavily relies on Keep-A-Changelog changelog.md - but I always forgot to add the changes or how to cut a release.

**This PR introduces a new config option `release.releasePR`.**

When enabled (default when the release workflow is rendered), an additional release-pr workflow opens or updates a release PR whenever CHANGELOG.md has unreleased entries. Merging that PR triggers a tag job in the goreleaser workflow so tagging and publishing stay in a single workflow run (the default GITHUB_TOKEN cannot trigger another workflow via tag push).

The release-pr workflow runs on push to the default branch (patch bump by default) and exposes a workflow_dispatch trigger with a patch/minor/major version input for manual minor or major releases.


### version bump selector
<img width="375" height="313" alt="image" src="https://github.com/user-attachments/assets/f8c34eb8-185e-45b1-9439-519e41ed7dce" />

### automated pull request
<img width="937" height="473" alt="image" src="https://github.com/user-attachments/assets/5f380e73-5851-42c1-93ff-b32f5eee53a8" />

### Example diff
<img width="869" height="688" alt="image" src="https://github.com/user-attachments/assets/f51d1c84-a713-466e-8598-e4aef81a959e" />
