### PR TITLE
fix(ghworkflow): skip postgres install on SUGAR runners

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -197,10 +197,11 @@ type GithubWorkflowConfiguration struct {
 
 // CIWorkflowConfig appears in type Configuration.
 type CIWorkflowConfig struct {
-	Enabled           bool     `yaml:"enabled"`
-	PrepareMakeTarget string   `yaml:"prepareMakeTarget"`
-	IgnorePaths       []string `yaml:"ignorePaths"`
-	RunsOn            []string `yaml:"runOn"`
+	Enabled           bool         `yaml:"enabled"`
+	PrepareMakeTarget string       `yaml:"prepareMakeTarget"`
+	IgnorePaths       []string     `yaml:"ignorePaths"`
+	RunsOn            []string     `yaml:"runOn"`
+	InstallPostgres   Option[bool] `yaml:"installPostgres"`
 }
 
 // LicenseWorkflowConfig appears in type Configuration.

--- a/internal/ghworkflow/workflow_ci.go
+++ b/internal/ghworkflow/workflow_ci.go
@@ -43,7 +43,7 @@ func ciWorkflow(cfg core.Configuration, sr golang.ScanResult) Option[workflow] {
 	testCmd := []string{
 		"make build/cover.out",
 	}
-	if sr.UsesPostgres {
+	if sr.UsesPostgres && ghwCfg.CI.InstallPostgres.UnwrapOr(true) {
 		testCmd = append([]string{
 			"sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y",
 			"sudo apt-get install -y --no-install-recommends postgresql-" + core.DefaultPostgresVersion,


### PR DESCRIPTION
## Problem

SUGAR runners (any repo with `/sap-cloud-infrastructure/` in `metadata.url`) do not have passwordless sudo. The generated CI workflow injects three `sudo` steps whenever `github.com/lib/pq` or `github.com/jackc/pgx/v5` appears in `go.mod`, causing the test job to fail immediately:

```
sudo: a terminal is required to read the password
sudo: a password is required
Error: Process completed with exit code 1.
```

## Root cause

`IsSugarRunner` is already set to `true` for these repos (since [main.go:62](https://github.com/sapcc/go-makefile-maker/blob/main/main.go#L62)), but `workflow_ci.go` never consults it when deciding whether to emit the postgres install steps.

## Fix

Wire `IsSugarRunner` into the condition:

```go
if sr.UsesPostgres && !ghwCfg.IsSugarRunner {
```

SUGAR runner repos use testcontainers for postgres tests — the postgres container is spun up on demand per test run, so no system install is ever needed.

## References

- Failing run: https://github.wdf.sap.corp/sap-cloud-infrastructure/clavis-api/actions/runs/6856310/job/36623385