### PR TITLE
Extended go-makefile-maker with extra fields

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -163,9 +163,10 @@ type SpellCheckConfiguration struct {
 
 // TyposConfiguration appears in type Configuration.
 type TyposConfiguration struct {
-	Enabled        Option[bool]      `yaml:"enabled"`
-	ExtendExcludes []string          `yaml:"extendExcludes"`
-	ExtendWords    map[string]string `yaml:"extendWords"`
+	Enabled                   Option[bool]      `yaml:"enabled"`
+	ExtendExcludes            []string          `yaml:"extendExcludes"`
+	ExtendIgnoreIdentifiersRe []string          `yaml:"extendIgnoreIdentifiersRe"`
+	ExtendWords               map[string]string `yaml:"extendWords"`
 }
 
 // IsEnabled encodes that the default state for the Enabled field is `true`.

--- a/internal/golangcilint/golangci.yaml.tmpl
+++ b/internal/golangcilint/golangci.yaml.tmpl
@@ -158,7 +158,7 @@ linters:
         - {{ . -}}
 {{ end }}
       toolchain-forbidden: true
-      go-version-pattern: 1\.\d+(\.\d+)?$
+      go-version-pattern: 1\.\d+(\.0)?$
     gosec:
       excludes:
         # gosec wants us to set a short ReadHeaderTimeout to avoid Slowloris attacks, but doing so would expose us to Keep-Alive race conditions (see https://iximiuz.com/en/posts/reverse-proxy-http-keep-alive-and-502s/

--- a/internal/golangcilint/golangci.yaml.tmpl
+++ b/internal/golangcilint/golangci.yaml.tmpl
@@ -158,7 +158,7 @@ linters:
         - {{ . -}}
 {{ end }}
       toolchain-forbidden: true
-      go-version-pattern: 1\.\d+(\.0)?$
+      go-version-pattern: 1\.\d+(\.\d+)?$
     gosec:
       excludes:
         # gosec wants us to set a short ReadHeaderTimeout to avoid Slowloris attacks, but doing so would expose us to Keep-Alive race conditions (see https://iximiuz.com/en/posts/reverse-proxy-http-keep-alive-and-502s/

--- a/internal/typos/typos.go
+++ b/internal/typos/typos.go
@@ -26,7 +26,8 @@ func RenderConfig(cfg core.Configuration) {
 	extendExcludes = append(extendExcludes, cfg.Typos.ExtendExcludes...)
 
 	must.Succeed(util.WriteFileFromTemplate(".typos.toml", typosConfigTemplate, map[string]any{
-		"ExtendExcludes": extendExcludes,
-		"ExtendWords":    cfg.Typos.ExtendWords,
+		"ExtendExcludes":            extendExcludes,
+		"ExtendIgnoreIdentifiersRe": cfg.Typos.ExtendIgnoreIdentifiersRe,
+		"ExtendWords":               cfg.Typos.ExtendWords,
 	}))
 }

--- a/internal/typos/typos.toml.tmpl
+++ b/internal/typos/typos.toml.tmpl
@@ -6,6 +6,16 @@
 {{ range $key, $value := .ExtendWords -}}
 {{$key}} = "{{$value}}"
 {{ end }}
+
+[default]
+{{- if .ExtendIgnoreIdentifiersRe }}
+extend-ignore-identifiers-re = [
+{{- range .ExtendIgnoreIdentifiersRe }}
+  "{{ . }}",
+{{- end }}
+]
+{{- end }}
+
 [files]
 extend-exclude = [
 {{- range .ExtendExcludes}}

--- a/internal/typos/typos.toml.tmpl
+++ b/internal/typos/typos.toml.tmpl
@@ -7,8 +7,8 @@
 {{$key}} = "{{$value}}"
 {{ end }}
 
-[default]
 {{- if .ExtendIgnoreIdentifiersRe }}
+[default]
 extend-ignore-identifiers-re = [
 {{- range .ExtendIgnoreIdentifiersRe }}
   "{{ . }}",


### PR DESCRIPTION
Extended go-makefile-maker to produce the correct output for repos that configure it

Fixes: [#1265](https://github.wdf.sap.corp/cc/unified-kubernetes/issues/1265) 