### PR TITLE
go-license-detector: allow `CCO-1.0`

### DIFF
--- a/.license-scan-rules.json
+++ b/.license-scan-rules.json
@@ -4,6 +4,7 @@
     "BSD-2-Clause",
     "BSD-2-Clause-FreeBSD",
     "BSD-3-Clause",
+    "CC0-1.0",
     "EPL-2.0",
     "ISC",
     "MIT",

--- a/internal/makefile/license-scan-rules.json
+++ b/internal/makefile/license-scan-rules.json
@@ -4,6 +4,7 @@
     "BSD-2-Clause",
     "BSD-2-Clause-FreeBSD",
     "BSD-3-Clause",
+    "CC0-1.0",
     "EPL-2.0",
     "ISC",
     "MIT",


### PR DESCRIPTION
Which comes from https://github.com/zeebo/assert, which is a transitive dependency of https://github.com/zeebo/xxh3