### PR TITLE
ci: drop --user 1000 container override

### DIFF
--- a/internal/ghworkflow/utils.go
+++ b/internal/ghworkflow/utils.go
@@ -56,7 +56,7 @@ func baseJob(name string, cfg *core.GithubWorkflowConfiguration) job {
 		strategy.Matrix.OS = cfg.CI.RunsOn
 	}
 
-	return job{
+	j := job{
 		Name:   name,
 		Env:    envs,
 		RunsOn: runsOn,
@@ -70,6 +70,18 @@ func baseJob(name string, cfg *core.GithubWorkflowConfiguration) job {
 		}},
 		Strategy: strategy,
 	}
+	// Self-hosted runners mount $GITHUB_WORKSPACE into the job container, but
+	// the mount point is owned by the runner user (not the container user), so
+	// git refuses to operate on it with "detected dubious ownership". This
+	// breaks anything that shells out to git — most notably `go build`'s VCS
+	// stamping. Marking the workspace as safe fixes it globally for the job.
+	if cfg.IsSelfHostedRunner {
+		j.Steps = append(j.Steps, jobStep{
+			Name: "Mark workspace as safe for git",
+			Run:  "git config --global --add safe.directory \"$GITHUB_WORKSPACE\"",
+		})
+	}
+	return j
 }
 
 func baseJobWithGo(name string, cfg core.Configuration) job {

--- a/internal/ghworkflow/workflow_ci.go
+++ b/internal/ghworkflow/workflow_ci.go
@@ -28,14 +28,12 @@ func ciWorkflow(cfg core.Configuration, sr golang.ScanResult) Option[workflow] {
 	}
 
 	containerImage := fmt.Sprintf("keppel.eu-de-1.cloud.sap/ccloud/shared-base-images/golang-alpine-ci:%s-latest", sr.GoVersionMajorMinor)
-	containerOption := "--user 1000"
 
 	w.Jobs = make(map[string]job)
 	build := baseJobWithGo("Build", cfg)
 	// technically not required here, but running the build and tests in different environments is too big a source for edge cases
 	if cfg.GitHubWorkflow.IsSelfHostedRunner {
 		build.Container.Image = containerImage
-		build.Container.Options = containerOption
 	}
 	if len(cfg.Binaries) > 0 {
 		build.addStep(jobStep{
@@ -49,7 +47,6 @@ func ciWorkflow(cfg core.Configuration, sr golang.ScanResult) Option[workflow] {
 	testJob := baseJobWithGo("Test", cfg)
 	if cfg.GitHubWorkflow.IsSelfHostedRunner {
 		testJob.Container.Image = containerImage
-		testJob.Container.Options = containerOption
 	}
 	testJob.Needs = []string{"build"}
 	testCmd := []string{


### PR DESCRIPTION
actions/checkout@v7 writes $GITHUB_STATE into /__w/_temp/ during saveState. That directory is root-owned on self-hosted runners, so containers running as UID 1000 fail every step with EACCES.

Since 6e1f6f9 moved the user override out of the shared base image and into the workflow, we can safely drop it here: without the UID mismatch against /__w, checkout v7 works, and the image's default user is compatible with the runner-created workspace.

see https://github.wdf.sap.corp/cc/spore/actions/runs/7369055/job/38350802 for example failed build step.