### PR TITLE
Revert "Revert "Fix sugar user id""

### DIFF
--- a/internal/ghworkflow/workflow_ci.go
+++ b/internal/ghworkflow/workflow_ci.go
@@ -28,7 +28,7 @@ func ciWorkflow(cfg core.Configuration, sr golang.ScanResult) Option[workflow] {
 	}
 
 	containerImage := fmt.Sprintf("keppel.eu-de-1.cloud.sap/ccloud/shared-base-images/golang-alpine-ci:%s-latest", sr.GoVersionMajorMinor)
-	containerOption := "--user 1000"
+	containerOption := "--user 1001"
 
 	w.Jobs = make(map[string]job)
 	build := baseJobWithGo("Build", cfg)


### PR DESCRIPTION
Reverts sapcc/go-makefile-maker#576

Closes #581

This is the official ID.

see https://docs.github.com/en/actions/how-tos/manage-runners/use-actions-runner-controller/deploy-runner-scale-sets#example-running-dind-rootless and https://github.com/actions/runner-images/issues/10936