### PR TITLE
ghworkflow: fix self-hosted CI git dubious-ownership

### DIFF
--- a/internal/ghworkflow/utils.go
+++ b/internal/ghworkflow/utils.go
@@ -91,6 +91,17 @@ func baseJobWithGo(name string, cfg core.Configuration) job {
 	return j
 }
 
+// markWorkspaceSafeStep marks the checked-out workspace as a safe git
+// directory. On self-hosted runners the CI container user differs from the
+// owner of the checkout tree, which makes git refuse to operate on it
+// ("detected dubious ownership") and breaks `go build`'s VCS stamping.
+func markWorkspaceSafeStep() jobStep {
+	return jobStep{
+		Name: "Mark workspace safe for git",
+		Run:  `git config --global --add safe.directory "$GITHUB_WORKSPACE"`,
+	}
+}
+
 // makeMultilineYAMLString adds \n to the strings and joins them.
 // yaml.Marshal() takes care of the rest.
 func makeMultilineYAMLString(in []string) string {

--- a/internal/ghworkflow/workflow_ci.go
+++ b/internal/ghworkflow/workflow_ci.go
@@ -28,14 +28,13 @@ func ciWorkflow(cfg core.Configuration, sr golang.ScanResult) Option[workflow] {
 	}
 
 	containerImage := fmt.Sprintf("keppel.eu-de-1.cloud.sap/ccloud/shared-base-images/golang-alpine-ci:%s-latest", sr.GoVersionMajorMinor)
-	containerOption := "--user 1001"
 
 	w.Jobs = make(map[string]job)
 	build := baseJobWithGo("Build", cfg)
 	// technically not required here, but running the build and tests in different environments is too big a source for edge cases
 	if cfg.GitHubWorkflow.IsSelfHostedRunner {
 		build.Container.Image = containerImage
-		build.Container.Options = containerOption
+		build.addStep(markWorkspaceSafeStep())
 	}
 	if len(cfg.Binaries) > 0 {
 		build.addStep(jobStep{
@@ -49,7 +48,7 @@ func ciWorkflow(cfg core.Configuration, sr golang.ScanResult) Option[workflow] {
 	testJob := baseJobWithGo("Test", cfg)
 	if cfg.GitHubWorkflow.IsSelfHostedRunner {
 		testJob.Container.Image = containerImage
-		testJob.Container.Options = containerOption
+		testJob.addStep(markWorkspaceSafeStep())
 	}
 	testJob.Needs = []string{"build"}
 	testCmd := []string{


### PR DESCRIPTION
The `--user 1001` container option on self-hosted CI jobs made the container user differ from the owner of the checked-out tree, so git refused to operate on the repository ("detected dubious ownership") and broke `go build`'s VCS stamping. This drops that option and instead adds a step marking the workspace as a safe git directory before build and test.

Tested by generating and running CI on both sugar and self-hosted (GitHub Enterprise group) runners — build and test are green on both.

Fixes #581