### PR TITLE
update doc references to WithTestDB()

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,8 +700,8 @@ sheet][ref-pattern-cheat-sheet]. This option is not defined by default.
 This is useful when you need to run some additional commands before being able to run `go build` or `golangci-lint`.
 For example when you are using `mockgen` or `go-bindata` through `verbatim`, you want to run the extra `verbatim` target through this option.
 
-If your application depends on `github.com/lib/pq`, the latest PostgreSQL server binaries will be available in the container when tests are executed.
-This is intended for use with `github.com/sapcc/go-bits/easypg`, which can launch a PostgreSQL server during `func TestMain`; see documentation in package easypg for details.
+If your application depends on `github.com/lib/pq` or `github.com/jackc/pgx`, the latest PostgreSQL server binaries will be available in the container when tests are executed.
+This is intended for use with [go.xyrillian.de/gg/pgruntime](https://pkg.go.dev/go.xyrillian.de/gg/pgruntime), which can launch a PostgreSQL server during `func TestMain`; see documentation over there for details.
 
 ### `githubWorkflow.pushContainerToGhcr`
 

--- a/internal/makefile/makefile.go
+++ b/internal/makefile/makefile.go
@@ -456,12 +456,13 @@ endif
 			},
 		}
 
-		// The current design of `easypg.WithTestDB()` came about because we wanted to get rid of the `./testing/with-postgres-db.sh` wrapper.
+		// The current design of `pgruntime.WithTestDB()` from go.xyrillian.de/gg/pgruntime
+		// came about because we wanted to get rid of the `./testing/with-postgres-db.sh` wrapper.
 		// Since wrappers outside of go test are not desirable, we can only hook into the TestMain level,
 		// and then there is no good way to deal with multiple test binaries running in parallel.
 		// We could use file locking to make them wait for each other, but that would just reverse this change with extra steps.
 		//
-		// usesPostgres reflects whether `github.com/lib/pq` is loaded. `github.com/sapcc/go-bits/easypg` hard depends on `github.com/lib/pq`.
+		// usesPostgres reflects whether a PostgreSQL driver (either `github.com/lib/pq` or `github.com/jackc/pgx`) is loaded.
 		singleThreaded := ""
 		if sr.UsesPostgres {
 			singleThreaded = "-p 1 "


### PR DESCRIPTION
We are in the process of retiring go-bits/easypg in favor of gg/pgruntime, and soon lib/pq in favor of jackc/pgx, so the docs should reference what we are actually using to avoid future confusion.