### PR TITLE
golangci-lint: increase default timeout to 5m

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,7 +9,7 @@
 version: "2"
 run:
   modules-download-mode: vendor
-  timeout: 3m0s # none by default in v2
+  timeout: 5m0s # none by default in v2
 
 formatters:
   enable:

--- a/internal/golangcilint/golangci_lint.go
+++ b/internal/golangcilint/golangci_lint.go
@@ -4,6 +4,7 @@
 package golangcilint
 
 import (
+	"cmp"
 	_ "embed"
 	"strconv"
 	"strings"
@@ -23,11 +24,6 @@ var (
 
 // RenderConfig writes the golanci-lint configuration files from the provided config and scan results.
 func RenderConfig(cfg core.Configuration, sr golang.ScanResult) {
-	timeout := 3 * time.Minute
-	if cfg.GolangciLint.Timeout != 0 {
-		timeout = cfg.GolangciLint.Timeout
-	}
-
 	must.Succeed(util.WriteFileFromTemplate(".golangci.yaml", configTemplate, map[string]any{
 		"ReplaceAllowList":  cfg.GolangciLint.ReplaceAllowList,
 		"EnableVendoring":   cfg.Golang.EnableVendoring,
@@ -37,7 +33,7 @@ func RenderConfig(cfg core.Configuration, sr golang.ScanResult) {
 		"ModulePath":        sr.ModulePath,
 		"ReviveRules":       cfg.GolangciLint.ReviveRules,
 		"SkipDirs":          cfg.GolangciLint.SkipDirs,
-		"Timeout":           timeout,
+		"Timeout":           cmp.Or(cfg.GolangciLint.Timeout, 5*time.Minute), // default to 5m0s
 		"WithControllerGen": cfg.ControllerGen.Enabled.UnwrapOr(sr.KubernetesController),
 		// liquid-ceph has an insane vendoring setup that we tried to replace with Go workspaces,
 		// but after getting stuck on bizarre module lookup errors, we decided to grandfather this in for now


### PR DESCRIPTION
When the go-makefile-maker pipeline performs autoupdates on all repos simultaneously, there is a lot of CPU load all at once, which causes many of the jobs to exceed the default 3m timeout. The quick and dirty fix is what this commit does: just allow for a longer timeout.

If that does not help substantively, we will have to look into limiting concurrency in the go-makefile-maker pipeline.