### PR TITLE
Switch internal container jobs to user 1000

### DIFF
--- a/internal/ghworkflow/workflow_ci.go
+++ b/internal/ghworkflow/workflow_ci.go
@@ -30,7 +30,7 @@ func ciWorkflow(cfg core.Configuration, sr golang.ScanResult) Option[workflow] {
 	containerImage := fmt.Sprintf("keppel.eu-de-1.cloud.sap/ccloud/shared-base-images/golang-alpine-ci:%s-latest", sr.GoVersionMajorMinor)
 	// see https://docs.github.com/en/actions/how-tos/manage-runners/use-actions-runner-controller/deploy-runner-scale-sets#example-running-dind-rootless
 	// and https://github.com/actions/runner-images/issues/10936
-	containerOption := "--user 1001"
+	containerOption := "--user 1000"
 
 	w.Jobs = make(map[string]job)
 	build := baseJobWithGo("Build", cfg)


### PR DESCRIPTION
When using user `1001`, that doesn't match the GHA runner environment user, the standard checkout action fails with

```
node:fs:2422
    return binding.writeFileUtf8(
                   ^

Error: EACCES: permission denied, open '/__w/_temp/_runner_file_commands/save_state_6d9f929e-4105-4fa0-8492-bc1f5ab3df22'
    at Object.writeFileSync (node:fs:2422:20)
    at Object.appendFileSync (node:fs:2504:6)
    at file_command_issueFileCommand (file:///__w/_actions/actions/checkout/3d3c42e5aac5ba805825da76410c181273ba90b1/dist/index.js:32043:33)
    at saveState (file:///__w/_actions/actions/checkout/3d3c42e5aac5ba805825da76410c181273ba90b1/dist/index.js:34803:16)
    at file:///__w/_actions/actions/checkout/3d3c42e5aac5ba805825da76410c181273ba90b1/dist/index.js:34956:5
    at ModuleJob.run (node:internal/modules/esm/module_job:439:25)
    at async node:internal/modules/esm/loader:633:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5) {
  errno: -13,
  code: 'EACCES',
  syscall: 'open',
  path: '/__w/_temp/_runner_file_commands/save_state_6d9f929e-4105-4fa0-8492-bc1f5ab3df22'
}

Node.js v24.16.0
```

Switching the runner's current user ID `1000` makes it work.