### PR TITLE
bump Go to 1.27

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,7 +17,7 @@
     "**/Dockerfile.tmpl"
   ],
   "constraints": {
-    "go": "1.26"
+    "go": "1.27"
   },
   "dependencyDashboardOSVVulnerabilitySummary": "all",
   "osvVulnerabilityAlerts": true,

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -31,11 +31,11 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           check-latest: true
-          go-version: 1.26.7
+          go-version: 1.27.0
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          version: v2.12.2
+          version: v2.13.1
       - name: Delete pre-installed shellcheck
         run: sudo rm -f "$(which shellcheck)"
       - name: Run shellcheck

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           check-latest: true
-          go-version: 1.26.7
+          go-version: 1.27.0
       - name: Build all binaries
         run: make build-all
   code_coverage:
@@ -72,7 +72,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           check-latest: true
-          go-version: 1.26.7
+          go-version: 1.27.0
       - name: Run tests and generate coverage report
         run: make build/cover.out
       - name: Archive code coverage results

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           check-latest: true
-          go-version: 1.26.7
+          go-version: 1.27.0
       - name: Initialize CodeQL
         uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:

--- a/.github/workflows/run-go-makefile-maker.yaml
+++ b/.github/workflows/run-go-makefile-maker.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           check-latest: true
-          go-version: 1.26.7
+          go-version: 1.27.0
 
       - name: Build, run and push
         run: |

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -75,7 +75,8 @@ linters:
   settings:
     dupword:
       # Do not choke on SQL statements like `INSERT INTO things (foo, bar, baz) VALUES (TRUE, TRUE, TRUE)`.
-      ignore: [ "TRUE", "FALSE", "NULL" ]
+      # Also do not choke on repeated "endif" in Makefile snippets in the go-makefile-maker repo.
+      ignore: [ "TRUE", "FALSE", "NULL", "endif" ]
     errcheck:
       check-type-assertions: false
       # Report about assignment of errors to blank identifier.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sapcc/go-makefile-maker
 
-go 1.26
+go 1.27
 
 require (
 	github.com/sapcc/go-api-declarations v1.25.0

--- a/internal/core/constants.go
+++ b/internal/core/constants.go
@@ -7,7 +7,7 @@ import "github.com/sapcc/go-makefile-maker/internal/util"
 
 const (
 	DefaultAlpineImage         = "3.24"
-	DefaultGoVersion           = "1.26.7"
+	DefaultGoVersion           = "1.27.0"
 	DefaultPostgresVersion     = "18"
 	DefaultLinkerdAwaitVersion = "0.3.3"
 	DefaultGitHubComRunsOn     = "ubuntu-latest"
@@ -75,7 +75,7 @@ const (
 	DownloadSyftAction      = util.RawString("anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0")
 	GHCRCleanupAction       = util.RawString("dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1")
 	GoCoverageReportAction  = util.RawString("fgrosse/go-coverage-report@e432de98ee94a276e8f666d25bfd76347665f75b # v1.3.1")
-	GolangCiLintVersion     = "v2.12.2"
+	GolangCiLintVersion     = "v2.13.1"
 	GolangciLintAction      = util.RawString("golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9")
 	GoreleaserAction        = util.RawString("goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7")
 	HelmSetupAction         = util.RawString("azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5")

--- a/internal/golangcilint/golangci.yaml.tmpl
+++ b/internal/golangcilint/golangci.yaml.tmpl
@@ -77,7 +77,8 @@ linters:
   settings:
     dupword:
       # Do not choke on SQL statements like `INSERT INTO things (foo, bar, baz) VALUES (TRUE, TRUE, TRUE)`.
-      ignore: [ "TRUE", "FALSE", "NULL" ]
+      # Also do not choke on repeated "endif" in Makefile snippets in the go-makefile-maker repo.
+      ignore: [ "TRUE", "FALSE", "NULL", "endif" ]
     errcheck:
       check-type-assertions: false
       # Report about assignment of errors to blank identifier.

--- a/shell.nix
+++ b/shell.nix
@@ -9,7 +9,7 @@ mkShell {
   nativeBuildInputs = [
     addlicense
     go-licence-detector
-    go_1_26
+    go_1_27
     golangci-lint
     gotools # goimports
     renovate


### PR DESCRIPTION
This includes the bump of golangci-lint past 2.13.0 for Go 1.27 support.