### PR TITLE
golangci-lint: do not enable modernize.embedlit for now

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -163,6 +163,10 @@ linters:
       enable-all: true
     nolintlint:
       require-specific: true
+    modernize:
+      disable:
+        # embedlit is new in Go 1.27 and triggers in a ton of places. We will enable this once Go 1.27 has settled a bit. (TODO: revisit this in a few weeks)
+        - embedlit
     perfsprint:
       # modernize generates nicer fix code
       concat-loop: false

--- a/internal/golangcilint/golangci.yaml.tmpl
+++ b/internal/golangcilint/golangci.yaml.tmpl
@@ -184,12 +184,14 @@ linters:
       enable-all: true
     nolintlint:
       require-specific: true
-    {{- if .WithControllerGen }}
     modernize:
       disable:
+        # embedlit is new in Go 1.27 and triggers in a ton of places. We will enable this once Go 1.27 has settled a bit. (TODO: revisit this in a few weeks)
+        - embedlit
+        {{- if .WithControllerGen }}
         # omitzero requires removing omitempty tags in kubernetes api struct types which are nested, which is interpreted by controller-gen and breaks the CRDs.
         - omitzero
-    {{- end }}
+        {{- end }}
     perfsprint:
       # modernize generates nicer fix code
       concat-loop: false


### PR DESCRIPTION
Since 1.27 is still on .0, I want to make it possible to revert to 1.26.x if showstopper bugs are discovered. Therefore, this particular fixer affecting tons of code locations (e.g. dozens in Limes alone) will stay disabled for now, and I will open a PR to revert this change in a few weeks.