### PR TITLE
Revert "golangci-lint: do not enable modernize.embedlit for now"

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -163,10 +163,6 @@ linters:
       enable-all: true
     nolintlint:
       require-specific: true
-    modernize:
-      disable:
-        # embedlit is new in Go 1.27 and triggers in a ton of places. We will enable this once Go 1.27 has settled a bit. (TODO: revisit this in a few weeks)
-        - embedlit
     perfsprint:
       # modernize generates nicer fix code
       concat-loop: false

--- a/internal/golangcilint/golangci.yaml.tmpl
+++ b/internal/golangcilint/golangci.yaml.tmpl
@@ -184,14 +184,12 @@ linters:
       enable-all: true
     nolintlint:
       require-specific: true
+    {{- if .WithControllerGen }}
     modernize:
       disable:
-        # embedlit is new in Go 1.27 and triggers in a ton of places. We will enable this once Go 1.27 has settled a bit. (TODO: revisit this in a few weeks)
-        - embedlit
-        {{- if .WithControllerGen }}
         # omitzero requires removing omitempty tags in kubernetes api struct types which are nested, which is interpreted by controller-gen and breaks the CRDs.
         - omitzero
-        {{- end }}
+    {{- end }}
     perfsprint:
       # modernize generates nicer fix code
       concat-loop: false


### PR DESCRIPTION
This reverts commit 7c6b3d3d89b219e2f8380397ff26671082fbba63.

This fixer can be enabled once Go 1.27 had a bit of time to simmer. Merge this a few weeks after 1.27 is out, preferably once we have had 1.27.1.

**Update:** Merge this once https://github.com/golang/go/issues/81353 has been released and we have included the respective patch version bump in this repo.